### PR TITLE
Cache external data in Github CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,6 +47,12 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.cfg', '**/requirements-dev.txt') }}
           restore-keys: ${{ runner.os }}-pip-
+      - name: Set up external data cache
+        uses: actions/cache@v2
+        with:
+          path: tests/data-files/external
+          key: ${{ runner.os }}-external-data-${{ hashFiles('tests/**/*.py') }}
+          restore-keys: ${{ runner.os }}-external-data-
       - name: Set up Conda with Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:


### PR DESCRIPTION
**Description:**
If there are no changes to the test files, we can reasonably assume that the external data requirements haven't changed. This might speed up _some_ CI runs.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.


