### PR TITLE
Allow remote urls for cogify

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
+import os.path
+
 import pytest
 
+from stactools.noaa_cdr import constants
+from stactools.noaa_cdr.constants import Cdr
 from tests import test_data
 
 
@@ -7,4 +11,13 @@ from tests import test_data
 def external_data(request: pytest.FixtureRequest) -> None:
     request.cls.netcdf_path_for_cogify = test_data.get_external_data(
         "heat_content_anomaly_0-2000_yearly.nc"
+    )
+
+
+@pytest.fixture
+def cogify_href() -> str:
+    return next(
+        href
+        for href in constants.hrefs(Cdr.OceanHeatContent)
+        if os.path.basename(href) == "heat_content_anomaly_0-2000_yearly.nc"
     )

--- a/tests/test_cogify.py
+++ b/tests/test_cogify.py
@@ -28,3 +28,16 @@ def test_cogify(infile: str, num_cogs: int) -> None:
         assert len(paths) == num_cogs
         for path in paths:
             assert os.path.exists(path)
+
+
+def test_cogify_href(cogify_href: str) -> None:
+    with TemporaryDirectory() as temporary_directory:
+        paths = noaa_cdr.cogify(cogify_href, temporary_directory)
+        assert len(paths) == 17
+        for path in paths:
+            assert os.path.exists(path)
+
+
+def test_cogify_href_no_output_directory(cogify_href: str) -> None:
+    with pytest.raises(Exception):
+        noaa_cdr.cogify(cogify_href)


### PR DESCRIPTION
**Description:**
Previously, only local paths were allowed for cogify. This enables remote urls.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
