### PR TITLE
Add slow marker for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,10 @@ To run the tests:
 ```shell
 pytest -vv
 ```
+
+Some tests that require network access or a lot of work are marked as "slow" and
+are skipped by default. To run the complete test suite, run:
+
+```sh
+pytest --slow
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os.path
+from typing import List
 
 import pytest
+from pytest import Config, FixtureRequest, Item, Parser
 
 from stactools.noaa_cdr import constants
 from stactools.noaa_cdr.constants import Cdr
@@ -8,7 +10,7 @@ from tests import test_data
 
 
 @pytest.fixture(scope="class")
-def external_data(request: pytest.FixtureRequest) -> None:
+def external_data(request: FixtureRequest) -> None:
     request.cls.netcdf_path_for_cogify = test_data.get_external_data(
         "heat_content_anomaly_0-2000_yearly.nc"
     )
@@ -21,3 +23,21 @@ def cogify_href() -> str:
         for href in constants.hrefs(Cdr.OceanHeatContent)
         if os.path.basename(href) == "heat_content_anomaly_0-2000_yearly.nc"
     )
+
+
+def pytest_addoption(parser: Parser) -> None:
+    parser.addoption(
+        "--slow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config: Config) -> None:
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config: Config, items: List[Item]) -> None:
+    if not config.getoption("--slow"):
+        skip_slow = pytest.mark.skip(reason="need --slow option to run")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)


### PR DESCRIPTION
**Description:**
This can be used to mark tests as slow, so they aren't run on a simple `pytest` invocation.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
