### PR TITLE
Refactor to use subclasses instead of a dataclass

### DIFF
--- a/scripts/extract_netcdf_asset_metadata.py
+++ b/scripts/extract_netcdf_asset_metadata.py
@@ -20,18 +20,17 @@ import fsspec
 import xarray
 from tqdm import tqdm
 
-from stactools.noaa_cdr import constants
-from stactools.noaa_cdr.constants import Cdr
+from stactools.noaa_cdr import Cdr
 
 metadata: Dict[str, Dict[str, Dict[str, str]]] = {}
-for cdr in Cdr:
-    print(f"Reading NetCDF files for {cdr}", file=sys.stderr)
-    metadata[cdr] = {}
-    for href in tqdm(constants.hrefs(cdr)):
+for cdr in Cdr.cdrs():
+    print(f"Reading NetCDF files for {cdr.slug()}", file=sys.stderr)
+    metadata[cdr.slug()] = {}
+    for href in tqdm(cdr.hrefs()):
         key = os.path.splitext(os.path.basename(href))[0]
         with fsspec.open(href) as file:
             with xarray.open_dataset(file, decode_times=False) as dataset:
-                metadata[cdr][key] = {
+                metadata[cdr.slug()][key] = {
                     "title": dataset.title,
                     "description": dataset.summary,
                 }

--- a/src/stactools/noaa_cdr/__init__.py
+++ b/src/stactools/noaa_cdr/__init__.py
@@ -1,10 +1,11 @@
 import stactools.core
 from stactools.cli.registry import Registry
 
+from stactools.noaa_cdr.cdr import Cdr
 from stactools.noaa_cdr.cogify import cogify
 from stactools.noaa_cdr.stac import create_collection
 
-__all__ = ["create_collection", "cogify"]
+__all__ = ["create_collection", "cogify", "Cdr"]
 
 stactools.core.use_fsspec()
 

--- a/src/stactools/noaa_cdr/cdr.py
+++ b/src/stactools/noaa_cdr/cdr.py
@@ -1,0 +1,185 @@
+import datetime
+from abc import ABC, abstractmethod
+from typing import Iterable, Type, cast
+
+from pystac import Extent, TemporalExtent
+
+from .constants import COLLECTION_ASSET_METADATA, SPATIAL_EXTENT
+
+
+class Cdr(ABC):
+    """Abstract base class for all supported CDRs."""
+
+    @classmethod
+    def from_slug(cls, slug: str) -> Type["Cdr"]:
+        """Returns the CDR class with the given slug.
+
+        Raises:
+            ValueError: Raised if the slug does not resolve to a CDR class.
+
+        Returns:
+            Type[Cdr]: A subclass of Cdr.
+        """
+        for subclass in cls.__subclasses__():
+            if subclass.slug() == slug:
+                return subclass
+        raise ValueError(f"Unknown CDR slug: {slug}")
+
+    @staticmethod
+    @abstractmethod
+    def slug() -> str:
+        """Returns a short, descriptive string for this CDR.
+
+        Should be slug-case.
+
+        Returns:
+            str: The slug
+        """
+        ...
+
+    @classmethod
+    def slugs(cls) -> Iterable[str]:
+        """Iterates over all registered CDR slugs.
+
+        Yields:
+            str: A Cdr subclass's slug.
+        """
+        for cdr in cls.cdrs():
+            yield cdr.slug()
+
+    @classmethod
+    def cdrs(cls) -> Iterable[Type["Cdr"]]:
+        """Iterates over all defined CDRs.
+
+        Yields:
+            Type[Cdr]: A Cdr subclass
+        """
+        for subclass in cls.__subclasses__():
+            yield subclass
+
+    @staticmethod
+    @abstractmethod
+    def title() -> str:
+        """Returns the collection title for this CDR.
+
+        Returns:
+            str: The title.
+        """
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def description() -> str:
+        """Returns the collection description for this CDR.
+
+        Returns:
+            str: The description.
+        """
+        ...
+
+    @classmethod
+    def extent(cls) -> Extent:
+        """Returns this CDR's temporal and spatial extent.
+
+        Returns:
+            Extent: The spatiotemporal extent of the CDR.
+        """
+        return Extent(SPATIAL_EXTENT, cls.temporal_extent())
+
+    @staticmethod
+    @abstractmethod
+    def temporal_extent() -> TemporalExtent:
+        """Returns this CDR's temporal extent.
+
+        Returns:
+            TemporalExtent: The temporal extent.
+        """
+        ...
+
+    @classmethod
+    def asset_title(cls, key: str) -> str:
+        """Returns an asset's title for this Cdr and asset key.
+
+        Args:
+            key (str): The asset key.
+
+        Returns:
+            str: The asset title.
+        """
+        # Cast is appropriate because we know the structure of the metadata json file.
+        return cast(str, COLLECTION_ASSET_METADATA[cls.slug()][key]["title"])
+
+    @classmethod
+    def asset_description(cls, key: str) -> str:
+        """Returns an asset's deescription for this Cdr and asset key.
+
+        Args:
+            key (str): The asset key.
+
+        Returns:
+            str: The asset description.
+        """
+        # Cast is appropriate because we know the structure of the metadata json file.
+        return cast(str, COLLECTION_ASSET_METADATA[cls.slug()][key]["description"])
+
+    @staticmethod
+    @abstractmethod
+    def hrefs() -> Iterable[str]:
+        """Iterates over a list of hrefs of this CDR's NetCDF assets."""
+        ...
+
+
+class OceanHeatContent(Cdr):
+    """The ocean heat content CDR.
+
+    https://www.ncei.noaa.gov/products/climate-data-records/global-ocean-heat-content
+    """
+
+    @staticmethod
+    def slug() -> str:
+        return "ocean-heat-content"
+
+    @staticmethod
+    def title() -> str:
+        return "Global Ocean Heat Content CDR"
+
+    @staticmethod
+    def description() -> str:
+        return (
+            "The Ocean Heat Content Climate Data Record (CDR) is a set "
+            "of ocean heat content anomaly (OHCA) time-series for 1955-present "
+            "on 3-monthly, yearly, and pentadal (five-yearly) scales. This CDR "
+            "quantifies ocean heat content change over time, which is an "
+            "essential metric for understanding climate change and the Earth's "
+            "energy budget. It provides time-series for multiple depth ranges in "
+            "the global ocean and each of the major basins (Atlantic, Pacific, "
+            "and Indian) divided by hemisphere (Northern, Southern)."
+        )
+
+    @staticmethod
+    def temporal_extent() -> TemporalExtent:
+        return TemporalExtent(intervals=[[datetime.datetime(1955, 1, 1), None]])
+
+    @staticmethod
+    def hrefs() -> Iterable[str]:
+        for variable in [
+            "heat_content",
+            "mean_halosteric_sea_level",
+            "mean_salinity",
+            "mean_temperature",
+            "mean_thermosteric_sea_level",
+            "mean_total_steric_sea_level",
+        ]:
+            for depth in ["100", "700", "2000"]:
+                for period in ["monthly", "pentad", "seasonal", "yearly"]:
+                    if period == "monthly" and variable != "heat_content":
+                        continue
+                    elif depth == "100" and variable not in [
+                        "mean_salinity",
+                        "mean_temperature",
+                    ]:
+                        continue
+                    yield (
+                        "https://www.ncei.noaa.gov/data/oceans/ncei/archive/data/0164586/"
+                        f"derived/{variable}_anomaly_0-{depth}_{period}.nc"
+                    )

--- a/src/stactools/noaa_cdr/commands.py
+++ b/src/stactools/noaa_cdr/commands.py
@@ -8,8 +8,8 @@ from click import Command, Group, Path
 from tqdm import tqdm
 
 import stactools.noaa_cdr
-from stactools.noaa_cdr import constants, stac
-from stactools.noaa_cdr.constants import Cdr
+from stactools.noaa_cdr import stac
+from stactools.noaa_cdr.cdr import Cdr
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ def create_noaa_cdr_command(cli: Group) -> Command:
                 list of available names.
             destination (str): An HREF for the Collection JSON
         """
-        cdr = Cdr.from_value(cdr_name)
+        cdr = Cdr.from_slug(cdr_name)
         collection = stac.create_collection(cdr)
         collection.set_self_href(destination)
         collection.save_object(include_self_link=include_self_link)
@@ -80,9 +80,9 @@ def create_noaa_cdr_command(cli: Group) -> Command:
                 a list of available CDRs.
             destination (str): The directory in which to store the CDR data.
         """
-        cdr = Cdr.from_value(name)
+        cdr = Cdr.from_slug(name)
         os.makedirs(destination, exist_ok=True)
-        for href in constants.hrefs(cdr):
+        for href in cdr.hrefs():
             path = os.path.join(destination, os.path.basename(href))
             if os.path.exists(path):
                 print(f"File already downloaded, skipping: {path}")
@@ -100,8 +100,8 @@ def create_noaa_cdr_command(cli: Group) -> Command:
     @noaa_cdr.command("list", short_help="List the names of all supported CDRs")
     def create_list_command() -> None:
         """Prints the names of all supported CDRs."""
-        for cdr in Cdr:
-            print(cdr.value)
+        for slug in Cdr.slugs():
+            print(slug)
 
     @noaa_cdr.command(
         "cogify",

--- a/src/stactools/noaa_cdr/constants.py
+++ b/src/stactools/noaa_cdr/constants.py
@@ -1,10 +1,8 @@
-import datetime
 import importlib.resources
 import json
 from enum import Enum, unique
-from typing import List, cast
 
-from pystac import Extent, Provider, ProviderRole, SpatialExtent, TemporalExtent
+from pystac import Provider, ProviderRole, SpatialExtent
 
 SPATIAL_EXTENT = SpatialExtent(bboxes=[-180.0, -90.0, 180.0, 90.0])
 PROVIDERS = [
@@ -30,112 +28,6 @@ COLLECTION_ASSET_METADATA = json.loads(
         "stactools.noaa_cdr", "collection-asset-metadata.json"
     )
 )
-
-
-@unique
-class Cdr(str, Enum):
-    # https://www.ncei.noaa.gov/products/climate-data-records/global-ocean-heat-content
-    OceanHeatContent = "ocean-heat-content"
-
-    @classmethod
-    def from_value(cls, value: str) -> "Cdr":
-        """Finds the Cdr that matches the provided value.
-
-        Args:
-            value (str): The name of the CDR.
-
-        Returns:
-            Cdr: The resolved Cdr.
-
-        Raises:
-            ValueError: Raised if the value is not a valid CDR name.
-        """
-        cdr = next(
-            (c for c in Cdr if c.value == value),
-            None,
-        )
-        if cdr is None:
-            raise ValueError("Encountered unexpected CDR name: " f"{value}")
-        else:
-            return cdr
-
-    @property
-    def title(self) -> str:
-        """Returns the Collection title for this CDR.
-
-        Returns:
-            str: The CDR title.
-        """
-        if self == Cdr.OceanHeatContent:
-            return "Global Ocean Heat Content CDR"
-        else:
-            raise NotImplementedError
-
-    @property
-    def description(self) -> str:
-        """Returns the Collection description for this CDR.
-
-        Returns:
-            str: The CDR description.
-        """
-        if self == Cdr.OceanHeatContent:
-            return (
-                "The Ocean Heat Content Climate Data Record (CDR) is a set "
-                "of ocean heat content anomaly (OHCA) time-series for 1955-present "
-                "on 3-monthly, yearly, and pentadal (five-yearly) scales. This CDR "
-                "quantifies ocean heat content change over time, which is an "
-                "essential metric for understanding climate change and the Earth's "
-                "energy budget. It provides time-series for multiple depth ranges in "
-                "the global ocean and each of the major basins (Atlantic, Pacific, "
-                "and Indian) divided by hemisphere (Northern, Southern)."
-            )
-        else:
-            raise NotImplementedError
-
-    @property
-    def extent(self) -> Extent:
-        """Returns this CDR's temporal and spatial extent.
-
-        Returns:
-            Extent: The spatiotemporal extent of the CDR.
-        """
-        return Extent(SPATIAL_EXTENT, self.temporal_extent)
-
-    @property
-    def temporal_extent(self) -> TemporalExtent:
-        """Returns this CDR's temporal.
-
-        Returns:
-            TemporalExtent: The temporal extent of the CDR.
-        """
-        if self == Cdr.OceanHeatContent:
-            return TemporalExtent(intervals=[[datetime.datetime(1955, 1, 1), None]])
-        else:
-            raise NotImplementedError
-
-    def asset_title(self, key: str) -> str:
-        """Returns the asset title for the given key.
-
-        Args:
-            key (str): The asset key.
-
-        Returns:
-            str: The asset title.
-        """
-        # Cast is appropriate because we know the structure of the metadata json file.
-        return cast(str, COLLECTION_ASSET_METADATA[self][key]["title"])
-
-    def asset_description(self, key: str) -> str:
-        """Returns the asset description for the given key.
-
-        Args:
-            key (str): The asset key.
-
-        Returns:
-            str: The asset description.
-        """
-        # Cast is appropriate because we know the structure of the metadata json file.
-        return cast(str, COLLECTION_ASSET_METADATA[self][key]["description"])
 
 
 @unique
@@ -174,38 +66,3 @@ class TimeResolution(str, Enum):
             )
         else:
             return time_resolution
-
-
-def hrefs(cdr: Cdr) -> List[str]:
-    """Returns all asset hrefs for the given CDR.
-
-    Args:
-        cdr (Cdr): The CDR.
-
-    Returns:
-        List[str]: The CDR hrefs.
-    """
-    hrefs = []
-    if cdr == Cdr.OceanHeatContent:
-        for variable in [
-            "heat_content",
-            "mean_halosteric_sea_level",
-            "mean_salinity",
-            "mean_temperature",
-            "mean_thermosteric_sea_level",
-            "mean_total_steric_sea_level",
-        ]:
-            for depth in ["100", "700", "2000"]:
-                for period in ["monthly", "pentad", "seasonal", "yearly"]:
-                    if period == "monthly" and variable != "heat_content":
-                        continue
-                    elif depth == "100" and variable not in [
-                        "mean_salinity",
-                        "mean_temperature",
-                    ]:
-                        continue
-                    hrefs.append(
-                        "https://www.ncei.noaa.gov/data/oceans/ncei/archive/data/0164586/"
-                        f"derived/{variable}_anomaly_0-{depth}_{period}.nc"
-                    )
-    return hrefs

--- a/src/stactools/noaa_cdr/stac.py
+++ b/src/stactools/noaa_cdr/stac.py
@@ -1,15 +1,16 @@
 import os.path
+from typing import Type
 
 from pystac import Asset, CatalogType, Collection
 
-from . import constants
-from .constants import LICENSE, PROVIDERS, Cdr
+from .cdr import Cdr
+from .constants import LICENSE, PROVIDERS
 
 DEFAULT_CATALOG_TYPE = CatalogType.SELF_CONTAINED
 
 
 def create_collection(
-    cdr: Cdr, catalog_type: CatalogType = DEFAULT_CATALOG_TYPE
+    cdr: Type[Cdr], catalog_type: CatalogType = DEFAULT_CATALOG_TYPE
 ) -> Collection:
     """Creates a STAC Collection for the provided CDR.
 
@@ -22,15 +23,15 @@ def create_collection(
     """
 
     collection = Collection(
-        id=f"noaa-cdr-{cdr.value}",
-        title=cdr.title,
-        description=cdr.description,
+        id=f"noaa-cdr-{cdr.slug()}",
+        title=cdr.title(),
+        description=cdr.description(),
         license=LICENSE,
         providers=PROVIDERS,
-        extent=cdr.extent,
+        extent=cdr.extent(),
         catalog_type=catalog_type,
     )
-    for href in constants.hrefs(cdr):
+    for href in cdr.hrefs():
         key = os.path.splitext(os.path.basename(href))[0]
         collection.add_asset(
             key,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,12 +3,11 @@ from typing import Any, Dict
 
 from stactools.testing.test_data import TestData
 
-from stactools.noaa_cdr import constants
-from stactools.noaa_cdr.constants import Cdr
+from stactools.noaa_cdr.cdr import OceanHeatContent
 
 external_data: Dict[str, Any] = dict()
 
-for href in constants.hrefs(Cdr.OceanHeatContent):
+for href in OceanHeatContent.hrefs():
     external_data[os.path.basename(href)] = {"url": href}
 
 test_data = TestData(__file__, external_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,7 @@ import os.path
 
 import pytest
 
-from stactools.noaa_cdr import constants
-from stactools.noaa_cdr.constants import Cdr
+from stactools.noaa_cdr.cdr import OceanHeatContent
 from tests import test_data
 
 
@@ -18,6 +17,6 @@ def external_data(request: pytest.FixtureRequest) -> None:
 def cogify_href() -> str:
     return next(
         href
-        for href in constants.hrefs(Cdr.OceanHeatContent)
+        for href in OceanHeatContent.hrefs()
         if os.path.basename(href) == "heat_content_anomaly_0-2000_yearly.nc"
     )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,8 +7,8 @@ import pytest
 from click import Command, Group
 from stactools.testing.cli_test import CliTestCase
 
+from stactools.noaa_cdr import Cdr
 from stactools.noaa_cdr.commands import create_noaa_cdr_command
-from stactools.noaa_cdr.constants import Cdr
 
 
 @pytest.mark.usefixtures("external_data")
@@ -58,7 +58,7 @@ class CommandsTest(CliTestCase):
     def test_list(self) -> None:
         result = self.run_command("noaa-cdr list")
         assert result.exit_code == 0
-        assert result.stdout.strip() == "\n".join(Cdr)
+        assert result.stdout.strip() == "\n".join(Cdr.slugs())
 
     def test_cogify(self) -> None:
         with TemporaryDirectory() as temporary_directory:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,9 +1,9 @@
 from stactools.noaa_cdr import stac
-from stactools.noaa_cdr.constants import Cdr
+from stactools.noaa_cdr.cdr import OceanHeatContent
 
 
 def test_create_collection() -> None:
-    collection = stac.create_collection(Cdr.OceanHeatContent)
+    collection = stac.create_collection(OceanHeatContent)
     assert collection.id == "noaa-cdr-ocean-heat-content"
     assert len(collection.assets) == 44
     for asset in collection.assets.values():


### PR DESCRIPTION
**Description:**
As I was implementing item creation, I discovered that we're going to need CDR-specific behavior (i.e. functions), not just CDR-specific data. It was getting unwieldy to handle that behavior with the dataclass-based specialization we had before, so this PR refactors to use an abstract base class.

Subclasses of this abstract base class will implement behavior via staticmethods and classmethods -- I _don't_ think we'll need to instantiate the classes. It's a little awkward, but it's one pattern for grouping shared behavior and data.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.

