### PR TITLE
Create items

### DIFF
--- a/src/stactools/noaa_cdr/commands.py
+++ b/src/stactools/noaa_cdr/commands.py
@@ -1,10 +1,12 @@
 import logging
 import os
-from typing import Optional
+from typing import List, Optional
 
 import click
+import pystac.utils
 import requests
 from click import Command, Group, Path
+from pystac import ItemCollection
 from tqdm import tqdm
 
 import stactools.noaa_cdr
@@ -55,18 +57,38 @@ def create_noaa_cdr_command(cli: Group) -> Command:
         collection.save_object(include_self_link=include_self_link)
         return None
 
-    @noaa_cdr.command("create-item", short_help="Create a STAC item")
-    @click.argument("source")
-    @click.argument("destination")
-    def create_item_command(source: str, destination: str) -> None:
-        """Creates a STAC Item
+    @noaa_cdr.command("create-items", short_help="Create STAC items from a NetCDF")
+    @click.argument("name")
+    @click.argument("source", nargs=-1)
+    @click.argument("destination", nargs=1)
+    @click.option(
+        "-c", "--cog-directory", help="The directory in which to store the COGs"
+    )
+    def create_item_command(
+        name: str, source: List[str], destination: str, cog_directory: Optional[str]
+    ) -> None:
+        """Creates a STAC ItemCollection for the provided NetCDFs.
 
         \b
         Args:
-            source (str): HREF of the Asset associated with the Item
-            destination (str): An HREF for the STAC Item
+            name (str): The CDR name.
+            source (str): HREF of the Asset associated with the Item.
+            destination (str): The destination file that will hold the item collection.
+            cog_directory (str): The folder that will hold the COGs. If not
+                provided, the COGs will be stored in the same directory as the item
+                collection.
         """
-        raise NotImplementedError
+        cdr = Cdr.from_slug(name)
+        if not cog_directory:
+            cog_directory = os.path.dirname(destination)
+        os.makedirs(cog_directory, exist_ok=True)
+        items = stac.create_items(cdr, cog_directory, source)
+        for item in items:
+            for key, asset in item.assets.items():
+                asset.href = pystac.utils.make_relative_href(asset.href, destination)
+                item.assets[key] = asset
+        item_collection = ItemCollection(items)
+        item_collection.save_object(destination)
 
     @noaa_cdr.command("download", short_help="Download data from NOAA's HTTP server")
     @click.argument("name")
@@ -123,9 +145,9 @@ def create_noaa_cdr_command(cli: Group) -> Command:
         """
         if outdir:
             os.makedirs(str(outdir), exist_ok=True)
-        paths = stactools.noaa_cdr.cogify(
+        cogs = stactools.noaa_cdr.cogify(
             infile, None if outdir is None else str(outdir)
         )
-        print(f"Wrote {len(paths)} COGs to {os.path.dirname(paths[0])}")
+        print(f"Wrote {len(cogs)} COGs to {os.path.dirname(cogs[0].path)}")
 
     return noaa_cdr

--- a/src/stactools/noaa_cdr/constants.py
+++ b/src/stactools/noaa_cdr/constants.py
@@ -2,9 +2,12 @@ import importlib.resources
 import json
 from enum import Enum, unique
 
+import shapely.geometry
 from pystac import Provider, ProviderRole, SpatialExtent
 
-SPATIAL_EXTENT = SpatialExtent(bboxes=[-180.0, -90.0, 180.0, 90.0])
+BBOX = [-180.0, -90.0, 180.0, 90.0]
+GEOMETRY = shapely.geometry.mapping(shapely.geometry.box(*BBOX))
+SPATIAL_EXTENT = SpatialExtent(bboxes=BBOX)
 PROVIDERS = [
     Provider(
         name="National Centers for Environmental Information",

--- a/tests/test_cogify.py
+++ b/tests/test_cogify.py
@@ -24,18 +24,18 @@ COGIFY_PARAMETERS = [
 def test_cogify(infile: str, num_cogs: int) -> None:
     external_data_path = test_data.get_external_data(infile)
     with TemporaryDirectory() as temporary_directory:
-        paths = noaa_cdr.cogify(external_data_path, temporary_directory)
-        assert len(paths) == num_cogs
-        for path in paths:
-            assert os.path.exists(path)
+        cogs = noaa_cdr.cogify(external_data_path, temporary_directory)
+        assert len(cogs) == num_cogs
+        for cog in cogs:
+            assert os.path.exists(cog.path)
 
 
 def test_cogify_href(cogify_href: str) -> None:
     with TemporaryDirectory() as temporary_directory:
-        paths = noaa_cdr.cogify(cogify_href, temporary_directory)
-        assert len(paths) == 17
-        for path in paths:
-            assert os.path.exists(path)
+        cogs = noaa_cdr.cogify(cogify_href, temporary_directory)
+        assert len(cogs) == 17
+        for cog in cogs:
+            assert os.path.exists(cog.path)
 
 
 def test_cogify_href_no_output_directory(cogify_href: str) -> None:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,5 +1,8 @@
+from tempfile import TemporaryDirectory
+
 from stactools.noaa_cdr import stac
 from stactools.noaa_cdr.cdr import OceanHeatContent
+from tests import test_data
 
 
 def test_create_collection() -> None:
@@ -14,3 +17,43 @@ def test_create_collection() -> None:
 
     collection.set_self_href("")
     collection.validate_all()
+
+
+def test_create_items_one_netcdf() -> None:
+    path = test_data.get_external_data("heat_content_anomaly_0-2000_yearly.nc")
+    with TemporaryDirectory() as temporary_directory:
+        items = stac.create_items(OceanHeatContent, temporary_directory, [path])
+    assert len(items) == 17
+    for item in items:
+        assert len(item.assets) == 1
+        item.validate()
+
+
+def test_create_items_two_netcdfs_same_items() -> None:
+    paths = [
+        test_data.get_external_data("heat_content_anomaly_0-2000_yearly.nc"),
+        test_data.get_external_data(
+            "mean_halosteric_sea_level_anomaly_0-2000_yearly.nc"
+        ),
+    ]
+    with TemporaryDirectory() as temporary_directory:
+        items = stac.create_items(OceanHeatContent, temporary_directory, paths)
+    assert len(items) == 17
+    for item in items:
+        assert len(item.assets) == 2
+        item.validate()
+
+
+def test_create_items_two_netcdfs_different_items() -> None:
+    paths = [
+        test_data.get_external_data("heat_content_anomaly_0-2000_yearly.nc"),
+        test_data.get_external_data(
+            "mean_halosteric_sea_level_anomaly_0-2000_pentad.nc"
+        ),
+    ]
+    with TemporaryDirectory() as temporary_directory:
+        items = stac.create_items(OceanHeatContent, temporary_directory, paths)
+    assert len(items) == 80
+    for item in items:
+        assert len(item.assets) == 1
+        item.validate()


### PR DESCRIPTION
**Description:**
Because one NetCDF maps to multiple items, a single `create-item` command doesn't make a whole lot of sense. Instead, we implement `create-items`, which takes one or more NetCDFs and produces a list of items (the command version saves a feature collection).

This method does the "hard" work of merging multiple NetCDFs into a set of items, e.g. yearly heat content and yearly salinity data are included in the same set of items, as their own assets.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
