### PR TITLE
fix: use inclusive ranges for pentadal

### DIFF
--- a/src/stactools/noaa_cdr/utils.py
+++ b/src/stactools/noaa_cdr/utils.py
@@ -62,7 +62,7 @@ def time_interval_as_str(
     elif time_resolution is TimeResolution.Yearly:
         return time.strftime("%Y")
     elif time_resolution is TimeResolution.Pentadal:
-        return f"{time.year - 2}-{time.year + 3}"
+        return f"{time.year - 2}-{time.year + 2}"
     else:
         raise NotImplementedError
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,7 @@ def test_add_months_to_datetime_fractional() -> None:
         (datetime.datetime(2022, 6, 15), TimeResolution.Monthly, "2022-06"),
         (datetime.datetime(2022, 2, 15), TimeResolution.Seasonal, "2022-Q1"),
         (datetime.datetime(2022, 7, 15), TimeResolution.Yearly, "2022"),
-        (datetime.datetime(2022, 7, 15), TimeResolution.Pentadal, "2020-2025"),
+        (datetime.datetime(2022, 7, 15), TimeResolution.Pentadal, "2020-2024"),
     ],
 )
 def test_time_interval_as_str(


### PR DESCRIPTION
**Related Issue(s):**
- Closes #12

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
