### PR TITLE
refactor, tests: make cli testing simpler

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,12 @@
 import os.path
-from typing import Any, Dict
+from typing import Any, Dict, Sequence, Union
 
+import click
+from click.testing import CliRunner, Result
 from stactools.testing.test_data import TestData
 
 from stactools.noaa_cdr import ocean_heat_content
+from stactools.noaa_cdr.commands import create_noaa_cdr_command
 
 external_data: Dict[str, Any] = {
     "oisst-avhrr-v02r01.20220913.nc": {
@@ -27,3 +30,19 @@ for href in ocean_heat_content.iter_noaa_hrefs():
 
 
 test_data = TestData(__file__, external_data)
+
+
+@click.group()
+def test_cli() -> None:
+    pass
+
+
+create_noaa_cdr_command(test_cli)
+
+
+def run_command(command: Union[str, Sequence[str]]) -> Result:
+    runner = CliRunner()
+    result = runner.invoke(test_cli, command, catch_exceptions=False)
+    if result.output:
+        print(result.output)
+    return result

--- a/tests/ocean_heat_content/test_commands.py
+++ b/tests/ocean_heat_content/test_commands.py
@@ -1,61 +1,45 @@
 import os.path
-from tempfile import TemporaryDirectory
-from typing import Callable, List
+from pathlib import Path
 
-from click import Command, Group
 from pystac import Collection, ItemCollection
-from stactools.testing.cli_test import CliTestCase
 
-from stactools.noaa_cdr.commands import create_noaa_cdr_command
-from tests import test_data
+from tests import run_command, test_data
 
 
-class CommandsTest(CliTestCase):
-    def create_subcommand_functions(self) -> List[Callable[[Group], Command]]:
-        return [create_noaa_cdr_command]
+def test_create_collection(tmp_path: Path) -> None:
+    destination = os.path.join(tmp_path, "collection.json")
+    result = run_command(f"noaa-cdr ocean-heat-content create-collection {destination}")
+    assert result.exit_code == 0, "\n{}".format(result.output)
+    paths = [p for p in os.listdir(tmp_path) if p.endswith(".json")]
+    assert len(paths) == 1
+    collection = Collection.from_file(destination)
+    assert collection.id == "noaa-cdr-ocean-heat-content"
+    collection.validate()
 
-    def test_create_collection(self) -> None:
-        with TemporaryDirectory() as temporary_directory:
-            destination = os.path.join(temporary_directory, "collection.json")
-            result = self.run_command(
-                f"noaa-cdr ocean-heat-content create-collection {destination}"
-            )
-            assert result.exit_code == 0, "\n{}".format(result.output)
-            paths = [p for p in os.listdir(temporary_directory) if p.endswith(".json")]
-            assert len(paths) == 1
-            collection = Collection.from_file(destination)
-            assert collection.id == "noaa-cdr-ocean-heat-content"
-            collection.validate()
 
-    def test_create_items(self) -> None:
-        with TemporaryDirectory() as temporary_directory:
-            destination = os.path.join(temporary_directory, "item-collection.json")
-            infile = test_data.get_external_data(
-                "heat_content_anomaly_0-2000_yearly.nc"
-            )
-            result = self.run_command(
-                f"noaa-cdr ocean-heat-content create-items {infile} {destination}"
-            )
-            assert result.exit_code == 0, "\n{}".format(result.output)
+def test_create_items(tmp_path: Path) -> None:
+    destination = os.path.join(tmp_path, "item-collection.json")
+    infile = test_data.get_external_data("heat_content_anomaly_0-2000_yearly.nc")
+    result = run_command(
+        f"noaa-cdr ocean-heat-content create-items {infile} {destination}"
+    )
+    assert result.exit_code == 0, "\n{}".format(result.output)
 
-            paths = [p for p in os.listdir(temporary_directory) if p.endswith(".json")]
-            assert len(paths) == 1
+    paths = [p for p in os.listdir(tmp_path) if p.endswith(".json")]
+    assert len(paths) == 1
 
-            item_collection = ItemCollection.from_file(
-                os.path.join(temporary_directory, paths[0])
-            )
-            assert len(item_collection) == 17
-            for item in item_collection:
-                item.validate()
+    item_collection = ItemCollection.from_file(os.path.join(tmp_path, paths[0]))
+    assert len(item_collection) == 17
+    for item in item_collection:
+        item.validate()
 
-    def test_download(self) -> None:
-        result = self.run_command("noaa-cdr ocean-heat-content download --help")
-        assert result.exit_code == 0
 
-    def test_cogify(self) -> None:
-        path = test_data.get_external_data("heat_content_anomaly_0-2000_yearly.nc")
-        with TemporaryDirectory() as temporary_directory:
-            result = self.run_command(
-                f"noaa-cdr ocean-heat-content cogify {path} -o {temporary_directory}"
-            )
-            assert result.exit_code == 0
+def test_download() -> None:
+    result = run_command("noaa-cdr ocean-heat-content download --help")
+    assert result.exit_code == 0
+
+
+def test_cogify(tmp_path: Path) -> None:
+    path = test_data.get_external_data("heat_content_anomaly_0-2000_yearly.nc")
+    result = run_command(f"noaa-cdr ocean-heat-content cogify {path} -o {tmp_path}")
+    assert result.exit_code == 0

--- a/tests/sea_surface_temperature_optimum_interpolation/test_commands.py
+++ b/tests/sea_surface_temperature_optimum_interpolation/test_commands.py
@@ -1,55 +1,43 @@
 import os.path
-from tempfile import TemporaryDirectory
-from typing import Callable, List
+from pathlib import Path
 
-from click import Command, Group
 from pystac import Collection, Item
-from stactools.testing.cli_test import CliTestCase
 
-from stactools.noaa_cdr.commands import create_noaa_cdr_command
-from tests import test_data
+from tests import run_command, test_data
 
 
-class CommandsTest(CliTestCase):
-    def create_subcommand_functions(self) -> List[Callable[[Group], Command]]:
-        return [create_noaa_cdr_command]
+def test_create_collection(tmp_path: Path) -> None:
+    destination = os.path.join(tmp_path, "collection.json")
+    result = run_command(
+        "noaa-cdr sea-surface-temperature-optimum-interpolation "
+        f"create-collection {destination}"
+    )
+    assert result.exit_code == 0, "\n{}".format(result.output)
+    paths = [p for p in os.listdir(tmp_path) if p.endswith(".json")]
+    assert len(paths) == 1
+    collection = Collection.from_file(destination)
+    assert collection.id == "noaa-cdr-sea-surface-temperature-optimum-interpolation"
+    collection.validate()
 
-    def test_create_collection(self) -> None:
-        with TemporaryDirectory() as temporary_directory:
-            destination = os.path.join(temporary_directory, "collection.json")
-            result = self.run_command(
-                "noaa-cdr sea-surface-temperature-optimum-interpolation "
-                f"create-collection {destination}"
-            )
-            assert result.exit_code == 0, "\n{}".format(result.output)
-            paths = [p for p in os.listdir(temporary_directory) if p.endswith(".json")]
-            assert len(paths) == 1
-            collection = Collection.from_file(destination)
-            assert (
-                collection.id
-                == "noaa-cdr-sea-surface-temperature-optimum-interpolation"
-            )
-            collection.validate()
 
-    def test_create_items(self) -> None:
-        with TemporaryDirectory() as temporary_directory:
-            destination = os.path.join(temporary_directory, "item.json")
-            infile = test_data.get_external_data("oisst-avhrr-v02r01.20220913.nc")
-            result = self.run_command(
-                "noaa-cdr sea-surface-temperature-optimum-interpolation "
-                f"create-item {infile} {destination}"
-            )
-            assert result.exit_code == 0, "\n{}".format(result.output)
-            paths = [p for p in os.listdir(temporary_directory) if p.endswith(".json")]
-            assert len(paths) == 1
-            item = Item.from_file(os.path.join(temporary_directory, paths[0]))
-            item.validate()
+def test_create_items(tmp_path: Path) -> None:
+    destination = os.path.join(tmp_path, "item.json")
+    infile = test_data.get_external_data("oisst-avhrr-v02r01.20220913.nc")
+    result = run_command(
+        "noaa-cdr sea-surface-temperature-optimum-interpolation "
+        f"create-item {infile} {destination}"
+    )
+    assert result.exit_code == 0, "\n{}".format(result.output)
+    paths = [p for p in os.listdir(tmp_path) if p.endswith(".json")]
+    assert len(paths) == 1
+    item = Item.from_file(os.path.join(tmp_path, paths[0]))
+    item.validate()
 
-    def test_cogify(self) -> None:
-        path = test_data.get_external_data("oisst-avhrr-v02r01.20220913.nc")
-        with TemporaryDirectory() as temporary_directory:
-            result = self.run_command(
-                "noaa-cdr sea-surface-temperature-optimum-interpolation "
-                f"cogify {path} -o {temporary_directory}"
-            )
-            assert result.exit_code == 0
+
+def test_cogify(tmp_path: Path) -> None:
+    path = test_data.get_external_data("oisst-avhrr-v02r01.20220913.nc")
+    result = run_command(
+        "noaa-cdr sea-surface-temperature-optimum-interpolation "
+        f"cogify {path} -o {tmp_path}"
+    )
+    assert result.exit_code == 0


### PR DESCRIPTION
**Description:**
Now that we're using pytest, we can use the `tmp_path` fixture rather than using `TemporaryDirectory` ourselves. Fixtures are hard to use with class-based tests, and I find that the class-based setup is too complicated for me anyways, so I also refactored things to be more direct for testing the CLI. Requesting a review from @pjhartzell just to make you aware of my thinking on this.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.


