### PR TITLE
Address review comments

### DIFF
--- a/examples/noaa-cdr-ocean-heat-content/collection.json
+++ b/examples/noaa-cdr-ocean-heat-content/collection.json
@@ -93,7 +93,7 @@
     "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
   ],
   "sci:doi": "10.7289/v53f4mvp",
-  "sci:citation": "Levitus, Sydney; Antonov, John I.; Boyer, Tim P.; Baranova, Olga K.; García, Hernán E.; Locarnini, Ricardo A.; Mishonov, Alexey V.; Reagan, James R.; [Seidov, Dan; Yarosh, Evgeney; Zweng, Melissa M. (2017). NCEI ocean heat content, temperature anomalies, salinity anomalies, thermosteric sea level anomalies, halosteric sea level anomalies, and total steric sea level anomalies from 1955 to present calculated from in situ oceanographic subsurface profile data (NCEI Accession 0164586). [indicate subset used]. NOAA National Centers for Environmental Information. Dataset. https://doi.org/10.7289/v53f4mvp. Accessed [date].",
+  "sci:citation": "Levitus, Sydney; Antonov, John I.; Boyer, Tim P.; Baranova, Olga K.; García, Hernán E.; Locarnini, Ricardo A.; Mishonov, Alexey V.; Reagan, James R.; [Seidov, Dan; Yarosh, Evgeney; Zweng, Melissa M. (2017). NCEI ocean heat content, temperature anomalies, salinity anomalies, thermosteric sea level anomalies, halosteric sea level anomalies, and total steric sea level anomalies from 1955 to present calculated from in situ oceanographic subsurface profile data (NCEI Accession 0164586).NOAA National Centers for Environmental Information. Dataset. https://doi.org/10.7289/v53f4mvp.",
   "item_assets": {
     "heat_content": {
       "title": "Ocean Heat Content anomalies from WOA09",
@@ -228,7 +228,8 @@
       "title": "Ocean Heat Content anomalies from WOA09 : heat_content_anomaly 0-700 m monthly 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "heat_content_anomaly_0-700_pentad": {
@@ -237,7 +238,8 @@
       "title": "Ocean Heat Content anomalies from WOA09 : heat_content_anomaly 0-700 m pentad 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "heat_content_anomaly_0-700_seasonal": {
@@ -246,7 +248,8 @@
       "title": "Ocean Heat Content anomalies from WOA09 : heat_content_anomaly 0-700 m seasonal 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "heat_content_anomaly_0-700_yearly": {
@@ -255,7 +258,8 @@
       "title": "Ocean Heat Content anomalies from WOA09 : heat_content_anomaly 0-700 m yearly 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "heat_content_anomaly_0-2000_monthly": {
@@ -264,7 +268,8 @@
       "title": "Ocean Heat Content anomalies from WOA09 : heat_content_anomaly 0-2000 m monthly 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "heat_content_anomaly_0-2000_pentad": {
@@ -273,7 +278,8 @@
       "title": "Ocean Heat Content anomalies from WOA09 : heat_content_anomaly 0-2000 m pentad 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "heat_content_anomaly_0-2000_seasonal": {
@@ -282,7 +288,8 @@
       "title": "Ocean Heat Content anomalies from WOA09 : heat_content_anomaly 0-2000 m seasonal 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "heat_content_anomaly_0-2000_yearly": {
@@ -291,7 +298,8 @@
       "title": "Ocean Heat Content anomalies from WOA09 : heat_content_anomaly 0-2000 m yearly 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_halosteric_sea_level_anomaly_0-700_pentad": {
@@ -300,7 +308,8 @@
       "title": "Mean halosteric sea level anomalies from WOA09 : mean_halosteric_sea_level_anomaly 0-700 m pentad 1.00 degree",
       "description": "Mean halosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_halosteric_sea_level_anomaly_0-700_seasonal": {
@@ -309,7 +318,8 @@
       "title": "Mean halosteric sea level anomalies from WOA09 : mean_halosteric_sea_level_anomaly 0-700 m seasonal 1.00 degree",
       "description": "Mean halosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_halosteric_sea_level_anomaly_0-700_yearly": {
@@ -318,7 +328,8 @@
       "title": "Mean halosteric sea level anomalies from WOA09 : mean_halosteric_sea_level_anomaly 0-700 m yearly 1.00 degree",
       "description": "Mean halosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_halosteric_sea_level_anomaly_0-2000_pentad": {
@@ -327,7 +338,8 @@
       "title": "Mean halosteric sea level anomalies from WOA09 : mean_halosteric_sea_level_anomaly 0-2000 m pentad 1.00 degree",
       "description": "Mean halosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_halosteric_sea_level_anomaly_0-2000_seasonal": {
@@ -336,7 +348,8 @@
       "title": "Mean halosteric sea level anomalies from WOA09 : mean_halosteric_sea_level_anomaly 0-2000 m seasonal 1.00 degree",
       "description": "Mean halosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_halosteric_sea_level_anomaly_0-2000_yearly": {
@@ -345,7 +358,8 @@
       "title": "Mean halosteric sea level anomalies from WOA09 : mean_halosteric_sea_level_anomaly 0-2000 m yearly 1.00 degree",
       "description": "Mean halosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_salinity_anomaly_0-100_pentad": {
@@ -354,7 +368,8 @@
       "title": "Mean salinity anomalies from WOA09 : mean_salinity_anomaly 0-100 m pentad 1.00 degree",
       "description": "Mean ocean salinity anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_salinity_anomaly_0-100_seasonal": {
@@ -363,7 +378,8 @@
       "title": "Mean salinity anomalies from WOA09 : mean_salinity_anomaly 0-100 m seasonal 1.00 degree",
       "description": "Mean ocean salinity anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_salinity_anomaly_0-100_yearly": {
@@ -372,7 +388,8 @@
       "title": "Mean salinity anomalies from WOA09 : mean_salinity_anomaly 0-100 m yearly 1.00 degree",
       "description": "Mean ocean salinity anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_salinity_anomaly_0-700_pentad": {
@@ -381,7 +398,8 @@
       "title": "Mean salinity anomalies from WOA09 : mean_salinity_anomaly 0-700 m pentad 1.00 degree",
       "description": "Mean ocean salinity anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_salinity_anomaly_0-700_seasonal": {
@@ -390,7 +408,8 @@
       "title": "Mean salinity anomalies from WOA09 : mean_salinity_anomaly 0-700 m seasonal 1.00 degree",
       "description": "Mean ocean salinity anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_salinity_anomaly_0-700_yearly": {
@@ -399,7 +418,8 @@
       "title": "Mean salinity anomalies from WOA09 : mean_salinity_anomaly 0-700 m yearly 1.00 degree",
       "description": "Mean ocean salinity anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_salinity_anomaly_0-2000_pentad": {
@@ -408,7 +428,8 @@
       "title": "Mean salinity anomalies from WOA09 : mean_salinity_anomaly 0-2000 m pentad 1.00 degree",
       "description": "Mean ocean salinity anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_salinity_anomaly_0-2000_seasonal": {
@@ -417,7 +438,8 @@
       "title": "Mean salinity anomalies from WOA09 : mean_salinity_anomaly 0-2000 m seasonal 1.00 degree",
       "description": "Mean ocean salinity anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_salinity_anomaly_0-2000_yearly": {
@@ -426,7 +448,8 @@
       "title": "Mean salinity anomalies from WOA09 : mean_salinity_anomaly 0-2000 m yearly 1.00 degree",
       "description": "Mean ocean salinity anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_temperature_anomaly_0-100_pentad": {
@@ -435,7 +458,8 @@
       "title": "Mean temperature anomalies from WOA09 : mean_temperature_anomaly 0-100 m pentad 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_temperature_anomaly_0-100_seasonal": {
@@ -444,7 +468,8 @@
       "title": "Mean temperature anomalies from WOA09 : mean_temperature_anomaly 0-100 m seasonal 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_temperature_anomaly_0-100_yearly": {
@@ -453,7 +478,8 @@
       "title": "Mean temperature anomalies from WOA09 : mean_temperature_anomaly 0-100 m yearly 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_temperature_anomaly_0-700_pentad": {
@@ -462,7 +488,8 @@
       "title": "Mean temperature anomalies from WOA09 : mean_temperature_anomaly 0-700 m pentad 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_temperature_anomaly_0-700_seasonal": {
@@ -471,7 +498,8 @@
       "title": "Mean temperature anomalies from WOA09 : mean_temperature_anomaly 0-700 m seasonal 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_temperature_anomaly_0-700_yearly": {
@@ -480,7 +508,8 @@
       "title": "Mean temperature anomalies from WOA09 : mean_temperature_anomaly 0-700 m yearly 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_temperature_anomaly_0-2000_pentad": {
@@ -489,7 +518,8 @@
       "title": "Mean temperature anomalies from WOA09 : mean_temperature_anomaly 0-2000 m pentad 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_temperature_anomaly_0-2000_seasonal": {
@@ -498,7 +528,8 @@
       "title": "Mean temperature anomalies from WOA09 : mean_temperature_anomaly 0-2000 m seasonal 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_temperature_anomaly_0-2000_yearly": {
@@ -507,7 +538,8 @@
       "title": "Mean temperature anomalies from WOA09 : mean_temperature_anomaly 0-2000 m yearly 1.00 degree",
       "description": "Mean ocean variable anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_thermosteric_sea_level_anomaly_0-700_pentad": {
@@ -516,7 +548,8 @@
       "title": "Mean thermosteric sea level anomalies from WOA09 : mean_thermosteric_sea_level_anomaly 0-700 m pentad 1.00 degree",
       "description": "Mean thermosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_thermosteric_sea_level_anomaly_0-700_seasonal": {
@@ -525,7 +558,8 @@
       "title": "Mean thermosteric sea level anomalies from WOA09 : mean_thermosteric_sea_level_anomaly 0-700 m seasonal 1.00 degree",
       "description": "Mean thermosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_thermosteric_sea_level_anomaly_0-700_yearly": {
@@ -534,7 +568,8 @@
       "title": "Mean thermosteric sea level anomalies from WOA09 : mean_thermosteric_sea_level_anomaly 0-700 m yearly 1.00 degree",
       "description": "Mean thermosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_thermosteric_sea_level_anomaly_0-2000_pentad": {
@@ -543,7 +578,8 @@
       "title": "Mean thermosteric sea level anomalies from WOA09 : mean_thermosteric_sea_level_anomaly 0-2000 m pentad 1.00 degree",
       "description": "Mean thermosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_thermosteric_sea_level_anomaly_0-2000_seasonal": {
@@ -552,7 +588,8 @@
       "title": "Mean thermosteric sea level anomalies from WOA09 : mean_thermosteric_sea_level_anomaly 0-2000 m seasonal 1.00 degree",
       "description": "Mean thermosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_thermosteric_sea_level_anomaly_0-2000_yearly": {
@@ -561,7 +598,8 @@
       "title": "Mean thermosteric sea level anomalies from WOA09 : mean_thermosteric_sea_level_anomaly 0-2000 m yearly 1.00 degree",
       "description": "Mean thermosteric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_total_steric_sea_level_anomaly_0-700_pentad": {
@@ -570,7 +608,8 @@
       "title": "Mean total steric sea level anomalies from WOA09 : mean_total_steric_sea_level_anomaly 0-700 m pentad 1.00 degree",
       "description": "Mean total steric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_total_steric_sea_level_anomaly_0-700_seasonal": {
@@ -579,7 +618,8 @@
       "title": "Mean total steric sea level anomalies from WOA09 : mean_total_steric_sea_level_anomaly 0-700 m seasonal 1.00 degree",
       "description": "Mean total steric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_total_steric_sea_level_anomaly_0-700_yearly": {
@@ -588,7 +628,8 @@
       "title": "Mean total steric sea level anomalies from WOA09 : mean_total_steric_sea_level_anomaly 0-700 m yearly 1.00 degree",
       "description": "Mean total steric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_total_steric_sea_level_anomaly_0-2000_pentad": {
@@ -597,7 +638,8 @@
       "title": "Mean total steric sea level anomalies from WOA09 : mean_total_steric_sea_level_anomaly 0-2000 m pentad 1.00 degree",
       "description": "Mean total steric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_total_steric_sea_level_anomaly_0-2000_seasonal": {
@@ -606,7 +648,8 @@
       "title": "Mean total steric sea level anomalies from WOA09 : mean_total_steric_sea_level_anomaly 0-2000 m seasonal 1.00 degree",
       "description": "Mean total steric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     },
     "mean_total_steric_sea_level_anomaly_0-2000_yearly": {
@@ -615,7 +658,8 @@
       "title": "Mean total steric sea level anomalies from WOA09 : mean_total_steric_sea_level_anomaly 0-2000 m yearly 1.00 degree",
       "description": "Mean total steric sea level anomaly from in situ profile data",
       "roles": [
-        "data"
+        "data",
+        "source"
       ]
     }
   }

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-1972-03-2000m/ocean-heat-content-1972-03-2000m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-1972-03-2000m/ocean-heat-content-1972-03-2000m.json
@@ -18,7 +18,7 @@
       -1.0,
       90.0
     ],
-    "datetime": "1972-03-16T12:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-1972-03-700m/ocean-heat-content-1972-03-700m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-1972-03-700m/ocean-heat-content-1972-03-700m.json
@@ -18,7 +18,7 @@
       -1.0,
       90.0
     ],
-    "datetime": "1972-03-16T12:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-100m/ocean-heat-content-2017-2021-100m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-100m/ocean-heat-content-2017-2021-100m.json
@@ -18,7 +18,7 @@
       -1.0,
       90.0
     ],
-    "datetime": "2019-07-01T00:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-2000m/ocean-heat-content-2017-2021-2000m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-2000m/ocean-heat-content-2017-2021-2000m.json
@@ -18,7 +18,7 @@
       -1.0,
       90.0
     ],
-    "datetime": "2019-07-01T00:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-700m/ocean-heat-content-2017-2021-700m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-700m/ocean-heat-content-2017-2021-700m.json
@@ -18,7 +18,7 @@
       -1.0,
       90.0
     ],
-    "datetime": "2019-07-01T00:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-100m/ocean-heat-content-2021-100m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-100m/ocean-heat-content-2021-100m.json
@@ -18,7 +18,7 @@
       -1.0,
       90.0
     ],
-    "datetime": "2021-07-01T00:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-2000m/ocean-heat-content-2021-2000m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-2000m/ocean-heat-content-2021-2000m.json
@@ -18,7 +18,7 @@
       -1.0,
       90.0
     ],
-    "datetime": "2021-07-01T00:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-700m/ocean-heat-content-2021-700m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-700m/ocean-heat-content-2021-700m.json
@@ -18,7 +18,7 @@
       -1.0,
       90.0
     ],
-    "datetime": "2021-07-01T00:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-100m/ocean-heat-content-2022-Q1-100m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-100m/ocean-heat-content-2022-Q1-100m.json
@@ -18,7 +18,7 @@
       -1.0,
       90.0
     ],
-    "datetime": "2022-02-15T00:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-2000m/ocean-heat-content-2022-Q1-2000m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-2000m/ocean-heat-content-2022-Q1-2000m.json
@@ -18,7 +18,7 @@
       -1.0,
       90.0
     ],
-    "datetime": "2022-02-15T00:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-700m/ocean-heat-content-2022-Q1-700m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-700m/ocean-heat-content-2022-Q1-700m.json
@@ -18,7 +18,7 @@
       -1.0,
       90.0
     ],
-    "datetime": "2022-02-15T00:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-sea-ice-concentration/collection.json
+++ b/examples/noaa-cdr-sea-ice-concentration/collection.json
@@ -480,7 +480,7 @@
     }
   },
   "sci:doi": "10.7265/efmz-2t65",
-  "sci:citation": "Meier, W. N., F. Fetterer, A. K. Windnagel, and S. Stewart. 2021. NOAA/NSIDC Climate Data Record of Passive Microwave Sea Ice Concentration, Version 4. [Indicate subset used]. Boulder, Colorado USA. NSIDC: National Snow and Ice Data Center https://doi.org/10.7265/efmz-2t65. [Date Accessed].",
+  "sci:citation": "Meier, W. N., F. Fetterer, A. K. Windnagel, and S. Stewart. 2021. NOAA/NSIDC Climate Data Record of Passive Microwave Sea Ice Concentration, Version 4. [Indicate subset used]. Boulder, Colorado USA. NSIDC: National Snow and Ice Data Center https://doi.org/10.7265/efmz-2t65. ",
   "title": "Sea Ice Concentration CDR",
   "extent": {
     "spatial": {

--- a/examples/noaa-cdr-sea-ice-concentration/seaice_conc_daily_nh_20211231_f17_v04r00/seaice_conc_daily_nh_20211231_f17_v04r00.json
+++ b/examples/noaa-cdr-sea-ice-concentration/seaice_conc_daily_nh_20211231_f17_v04r00/seaice_conc_daily_nh_20211231_f17_v04r00.json
@@ -20,7 +20,7 @@
       -25000.0,
       5850000.0
     ],
-    "datetime": "2021-12-31T00:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-sea-ice-concentration/seaice_conc_daily_nh_20211231_f17_v04r00/seaice_conc_daily_nh_20211231_f17_v04r00.json
+++ b/examples/noaa-cdr-sea-ice-concentration/seaice_conc_daily_nh_20211231_f17_v04r00/seaice_conc_daily_nh_20211231_f17_v04r00.json
@@ -88,7 +88,8 @@
         {
           "nodata": 255,
           "data_type": "uint8",
-          "scale": 0.009999999776482582
+          "scale": 0.009999999776482582,
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:classes": [
@@ -124,7 +125,8 @@
       "raster:bands": [
         {
           "nodata": 255,
-          "data_type": "uint8"
+          "data_type": "uint8",
+          "spatial_resolution": 25000.0
         }
       ],
       "roles": [
@@ -139,7 +141,8 @@
         {
           "nodata": 255,
           "data_type": "uint8",
-          "scale": 0.009999999776482582
+          "scale": 0.009999999776482582,
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:classes": [
@@ -176,7 +179,8 @@
         {
           "nodata": 255,
           "data_type": "uint8",
-          "scale": 0.009999999776482582
+          "scale": 0.009999999776482582,
+          "spatial_resolution": 25000.0
         }
       ],
       "roles": [
@@ -190,7 +194,8 @@
       "raster:bands": [
         {
           "nodata": 0,
-          "data_type": "uint8"
+          "data_type": "uint8",
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:bitfields": [
@@ -326,7 +331,8 @@
       "raster:bands": [
         {
           "nodata": 0,
-          "data_type": "uint8"
+          "data_type": "uint8",
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:bitfields": [
@@ -432,7 +438,8 @@
       "raster:bands": [
         {
           "nodata": "nan",
-          "data_type": "float32"
+          "data_type": "float32",
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:classes": [
@@ -468,7 +475,8 @@
       "raster:bands": [
         {
           "nodata": 0,
-          "data_type": "uint8"
+          "data_type": "uint8",
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:classes": [

--- a/examples/noaa-cdr-sea-surface-temperature-optimum-interpolation/collection.json
+++ b/examples/noaa-cdr-sea-surface-temperature-optimum-interpolation/collection.json
@@ -108,7 +108,7 @@
     }
   },
   "sci:doi": "10.25921/RE9P-PT57",
-  "sci:citation": "Huang, Boyin; Liu, Chunying; Banzon, Viva F.; Freeman, Eric; Graham, Garrett; Hankins, Bill; Smith, Thomas M.; Zhang, Huai-Min. (2020): NOAA 0.25-degree Daily Optimum Interpolation Sea Surface Temperature (OISST), Version 2.1. [indicate subset used]. NOAA National Centers for Environmental Information. https://doi.org/10.25921/RE9P-PT57. Accessed [date].",
+  "sci:citation": "Huang, Boyin; Liu, Chunying; Banzon, Viva F.; Freeman, Eric; Graham, Garrett; Hankins, Bill; Smith, Thomas M.; Zhang, Huai-Min. (2020): NOAA 0.25-degree Daily Optimum Interpolation Sea Surface Temperature (OISST), Version 2.1. NOAA National Centers for Environmental Information. https://doi.org/10.25921/RE9P-PT57.",
   "title": "Sea Surface Temperature - Optimum Interpolation CDR",
   "extent": {
     "spatial": {

--- a/examples/noaa-cdr-sea-surface-temperature-optimum-interpolation/oisst-avhrr-v02r01.20220913/oisst-avhrr-v02r01.20220913.json
+++ b/examples/noaa-cdr-sea-surface-temperature-optimum-interpolation/oisst-avhrr-v02r01.20220913/oisst-avhrr-v02r01.20220913.json
@@ -19,7 +19,7 @@
       -0.25,
       90.0
     ],
-    "datetime": "2022-09-13T12:00:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0.json
@@ -19,7 +19,7 @@
       -0.25,
       90.0
     ],
-    "datetime": "2021-08-31T01:30:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1.json
@@ -19,7 +19,7 @@
       -0.25,
       90.0
     ],
-    "datetime": "2021-08-31T04:30:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2.json
@@ -19,7 +19,7 @@
       -0.25,
       90.0
     ],
-    "datetime": "2021-08-31T07:30:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3.json
@@ -19,7 +19,7 @@
       -0.25,
       90.0
     ],
-    "datetime": "2021-08-31T10:30:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4.json
@@ -19,7 +19,7 @@
       -0.25,
       90.0
     ],
-    "datetime": "2021-08-31T13:30:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5.json
@@ -19,7 +19,7 @@
       -0.25,
       90.0
     ],
-    "datetime": "2021-08-31T16:30:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6.json
@@ -19,7 +19,7 @@
       -0.25,
       90.0
     ],
-    "datetime": "2021-08-31T19:30:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7.json
@@ -19,7 +19,7 @@
       -0.25,
       90.0
     ],
-    "datetime": "2021-08-31T22:30:00Z"
+    "datetime": null
   },
   "geometry": {
     "type": "Polygon",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/collection.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/collection.json
@@ -111,7 +111,7 @@
     }
   },
   "sci:doi": "10.7289/V5FB510W",
-  "sci:citation": "Clayson, Carol Anne; Brown, Jeremiah; and NOAA CDR Program (2016). NOAA Climate Data Record (CDR) of Sea Surface Temperature - WHOI, Version 2. [indicate subset used]. NOAA National Climatic Data Center. doi:10.7289/V5FB510W [access date].",
+  "sci:citation": "Clayson, Carol Anne; Brown, Jeremiah; and NOAA CDR Program (2016). NOAA Climate Data Record (CDR) of Sea Surface Temperature - WHOI, Version 2. NOAA National Climatic Data Center. doi:10.7289/V5FB510W",
   "title": "Sea Surface Temperature - WHOI CDR",
   "extent": {
     "spatial": {

--- a/src/stactools/noaa_cdr/ocean_heat_content/constants.py
+++ b/src/stactools/noaa_cdr/ocean_heat_content/constants.py
@@ -50,9 +50,9 @@ CITATION = (
     "NCEI ocean heat content, temperature anomalies, salinity anomalies, thermosteric "
     "sea level anomalies, halosteric sea level anomalies, and total steric sea level "
     "anomalies from 1955 to present calculated from in situ oceanographic subsurface "
-    "profile data (NCEI Accession 0164586). [indicate subset used]. "
+    "profile data (NCEI Accession 0164586)."
     "NOAA National Centers for Environmental Information. Dataset. "
-    "https://doi.org/10.7289/v53f4mvp. Accessed [date]."
+    "https://doi.org/10.7289/v53f4mvp."
 )
 TRANSFORM = Affine(1.0, 0.0, -180.0, 0.0, -1.0, 90.0)
 EPSG = 4326

--- a/src/stactools/noaa_cdr/ocean_heat_content/stac.py
+++ b/src/stactools/noaa_cdr/ocean_heat_content/stac.py
@@ -81,7 +81,7 @@ def create_collection(
                 title=ASSET_METADATA[key]["title"],
                 description=ASSET_METADATA[key]["description"],
                 media_type="application/netcdf",
-                roles=["data"],
+                roles=["data", "source"],
             ),
         )
     scientific = ScientificExtension.ext(collection, add_if_missing=True)

--- a/src/stactools/noaa_cdr/ocean_heat_content/stac.py
+++ b/src/stactools/noaa_cdr/ocean_heat_content/stac.py
@@ -151,7 +151,7 @@ def _update_items(items: List[Item], cogs: List[Cog]) -> List[Item]:
                 id=id,
                 geometry=GLOBAL_GEOMETRY,
                 bbox=GLOBAL_BBOX,
-                datetime=c.datetime,
+                datetime=None,
                 properties={
                     "start_datetime": pystac.utils.datetime_to_str(c.start_datetime),
                     "end_datetime": pystac.utils.datetime_to_str(c.end_datetime),

--- a/src/stactools/noaa_cdr/sea_ice_concentration/cog.py
+++ b/src/stactools/noaa_cdr/sea_ice_concentration/cog.py
@@ -4,6 +4,7 @@ from pystac import Asset
 
 from .. import cog
 from ..profile import BandProfile
+from .constants import SPATIAL_RESOLUTION
 
 KEYS_WITH_CLASSES = [
     "cdr_seaice_conc",
@@ -20,6 +21,7 @@ def cogify(href: str, directory: str) -> Dict[str, Asset]:
 
 class SeaIceConcentrationBandProfile(BandProfile):
     def update_cog_asset(self, key: str, asset: Asset) -> Asset:
+        asset.extra_fields["raster:bands"][0]["spatial_resolution"] = SPATIAL_RESOLUTION
         if key in KEYS_WITH_CLASSES:
             asset.extra_fields["classification:classes"] = self.classes()
         elif key in KEYS_WITH_BITFIELDS:

--- a/src/stactools/noaa_cdr/sea_ice_concentration/constants.py
+++ b/src/stactools/noaa_cdr/sea_ice_concentration/constants.py
@@ -89,3 +89,4 @@ HOMEPAGE_LINK = Link(
     media_type=MediaType.HTML,
     title="Sea Ice Concentration CDR",
 )
+SPATIAL_RESOLUTION = 25000.0

--- a/src/stactools/noaa_cdr/sea_ice_concentration/constants.py
+++ b/src/stactools/noaa_cdr/sea_ice_concentration/constants.py
@@ -45,7 +45,6 @@ CITATION = (
     "Passive Microwave Sea Ice Concentration, Version 4. "
     "[Indicate subset used]. Boulder, Colorado USA. NSIDC: National "
     "Snow and Ice Data Center https://doi.org/10.7265/efmz-2t65. "
-    "[Date Accessed]."
 )
 PROVIDERS = [
     Provider(

--- a/src/stactools/noaa_cdr/sea_surface_temperature_optimum_interpolation/constants.py
+++ b/src/stactools/noaa_cdr/sea_surface_temperature_optimum_interpolation/constants.py
@@ -32,8 +32,8 @@ CITATION = (
     "Huang, Boyin; Liu, Chunying; Banzon, Viva F.; Freeman, Eric; Graham, "
     "Garrett; Hankins, Bill; Smith, Thomas M.; Zhang, Huai-Min. (2020): NOAA "
     "0.25-degree Daily Optimum Interpolation Sea Surface Temperature (OISST), Version "
-    "2.1. [indicate subset used]. NOAA National Centers for Environmental "
-    "Information. https://doi.org/10.25921/RE9P-PT57. Accessed [date]."
+    "2.1. NOAA National Centers for Environmental "
+    "Information. https://doi.org/10.25921/RE9P-PT57."
 )
 DOI = "10.25921/RE9P-PT57"
 LICENSE_LINK = Link(

--- a/src/stactools/noaa_cdr/sea_surface_temperature_whoi/constants.py
+++ b/src/stactools/noaa_cdr/sea_surface_temperature_whoi/constants.py
@@ -29,8 +29,8 @@ DOI = "10.7289/V5FB510W"
 CITATION = (
     "Clayson, Carol Anne; Brown, Jeremiah; and NOAA CDR "
     "Program (2016). NOAA Climate Data Record (CDR) of Sea Surface "
-    "Temperature - WHOI, Version 2. [indicate subset used]. NOAA "
-    "National Climatic Data Center. doi:10.7289/V5FB510W [access date]."
+    "Temperature - WHOI, Version 2. NOAA "
+    "National Climatic Data Center. doi:10.7289/V5FB510W"
 )
 
 LICENSE_LINK = Link(

--- a/src/stactools/noaa_cdr/sea_surface_temperature_whoi/stac.py
+++ b/src/stactools/noaa_cdr/sea_surface_temperature_whoi/stac.py
@@ -45,7 +45,6 @@ def create_items(href: str, directory: str) -> List[Item]:
             ):
                 item = base_item.clone()
                 item.id = f"{item.id}-{i}"
-                item.datetime = dt
                 item.common_metadata.start_datetime = (
                     dt
                     - dateutil.relativedelta.relativedelta(

--- a/src/stactools/noaa_cdr/stac.py
+++ b/src/stactools/noaa_cdr/stac.py
@@ -7,7 +7,7 @@ import xarray
 from pystac import Asset, Item
 from pystac.extensions.projection import ProjectionExtension
 
-from . import cog, time
+from . import cog
 from .constants import NETCDF_ASSET_KEY, PROCESSING_EXTENSION_SCHEMA
 from .profile import DatasetProfile
 
@@ -25,7 +25,7 @@ def create_item(href: str, id: Optional[str] = None) -> Item:
                 id=id,
                 geometry=profile.geometry,
                 bbox=profile.bbox,
-                datetime=time.datetime64_to_datetime(ds.time.data[0]),
+                datetime=None,
                 properties={
                     "start_datetime": ds.time_coverage_start,
                     "end_datetime": ds.time_coverage_end,

--- a/tests/ocean_heat_content/test_stac.py
+++ b/tests/ocean_heat_content/test_stac.py
@@ -39,8 +39,9 @@ def test_create_items_one_netcdf() -> None:
     assert len(items) == 17
     for item in items:
         assert len(item.assets) == 1
-        assert item.datetime
-        year = item.datetime.year
+        assert item.datetime is None
+        assert item.common_metadata.start_datetime
+        year = item.common_metadata.start_datetime.year
         assert item.common_metadata.start_datetime == datetime.datetime(
             year, 1, 1, tzinfo=tzutc()
         )

--- a/tests/ocean_heat_content/test_stac.py
+++ b/tests/ocean_heat_content/test_stac.py
@@ -21,7 +21,8 @@ def test_create_collection() -> None:
         assert asset.title is not None
         assert asset.description is not None
         assert asset.media_type == "application/netcdf"
-        assert asset.roles == ["data"]
+        assert asset.roles
+        assert set(asset.roles) == {"data", "source"}
 
     scientific = ScientificExtension.ext(collection)
     assert scientific.doi == "10.7289/v53f4mvp"

--- a/tests/sea_ice_concentration/test_stac.py
+++ b/tests/sea_ice_concentration/test_stac.py
@@ -62,6 +62,8 @@ def test_cogify(tmp_path: Path) -> None:
     path = test_data.get_path("data-files/seaice_conc_daily_nh_20211231_f17_v04r00.nc")
     assets = cog.cogify(path, str(tmp_path))
     assert len(assets) == 8
+    for asset in assets.values():
+        assert asset.extra_fields["raster:bands"][0]["spatial_resolution"]
     for key in [
         "cdr_seaice_conc",
         "nsidc_bt_seaice_conc",

--- a/tests/sea_ice_concentration/test_stac.py
+++ b/tests/sea_ice_concentration/test_stac.py
@@ -41,6 +41,7 @@ def test_create_item(file_name: str, shape: List[int], transform: List[float]) -
     path = test_data.get_path(f"data-files/{file_name}")
     item = stac.create_item(path)
     assert item.id == Path(file_name).stem
+    assert item.datetime is None
 
     projection = ProjectionExtension.ext(item)
     _ = pyproj.CRS(projection.wkt2)

--- a/tests/sea_surface_temperature_optimum_interpolation/test_stac.py
+++ b/tests/sea_surface_temperature_optimum_interpolation/test_stac.py
@@ -22,7 +22,7 @@ def test_create_item() -> None:
     path = test_data.get_external_data("oisst-avhrr-v02r01.20220913.nc")
     item = stac.create_item(path)
     assert item.id == "oisst-avhrr-v02r01.20220913"
-    assert item.datetime == datetime.datetime(2022, 9, 13, 12, 0, 0, tzinfo=tzutc())
+    assert item.datetime is None
     assert item.common_metadata.start_datetime == datetime.datetime(
         2022, 9, 13, 0, 0, 0, tzinfo=tzutc()
     )

--- a/tests/sea_surface_temperature_whoi/test_stac.py
+++ b/tests/sea_surface_temperature_whoi/test_stac.py
@@ -16,6 +16,7 @@ def test_create_items(tmp_path: Path) -> None:
     for i, item in enumerate(items):
         assert item.id == f"SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-{i}"
         assert item.bbox == [-180, -90, 180, 90]
+        assert item.datetime is None
         assert len(item.assets) == 3
         assert "fill_missing_qc" in item.assets
         assert "sea_surface_temperature" in item.assets


### PR DESCRIPTION
**Related Issue(s):**
- Closes #35 

**Description:**

> Is it worth adding something like source to the roles of the NetCDF assets that are on the collections?

Done.

> Use of an average datetime (e.g., middle of a year) instead of setting it to null: is that the recommended practice? I've been avoiding setting datetime for long time period data since the data is not necessarily representative of state as of a single date.

I was including the `datetime` because that's the value of the singular `time` value in the data array. However, I think agree with you that the start/end setup is better for expressing what these data are. Fixed.

> Any opinions on use of singular rather than plural for units? For example, degree Celsius versus degrees Celsius.

I pulled these values straight from the NetCDFs so (IMO) it's not worth the effort to remap. If there were a "best practices for units" document that we could align to then it'd be worth it, but since we don't have that <shrug>

> spatial resolution in raster:bands?

We're in degree-based grids for everything _except_ sea ice concentration, so the forced meter units for `spatial_resolution` is kind of non-sensical. Added for sea ice.

> sci:citation on the collections: fill in or delete: [indicate subset used] and Accessed [date]

Done.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Examples have been updated to reflect changes, if applicable

