### PR TITLE
Remove netcdf from whoi items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ number as needed.
 
 ### Removed
 
-- Nothing.
+- NetCDF assets from WHOI items ([#37](https://github.com/stactools-packages/noaa-cdr/pull/37))
 
 ### Fixed
 

--- a/examples/noaa-cdr-sea-ice-concentration/collection.json
+++ b/examples/noaa-cdr-sea-ice-concentration/collection.json
@@ -55,7 +55,8 @@
         {
           "nodata": 255,
           "data_type": "uint8",
-          "scale": 0.009999999776482582
+          "scale": 0.009999999776482582,
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:classes": [
@@ -90,7 +91,8 @@
         {
           "nodata": 255,
           "data_type": "uint8",
-          "scale": 0.009999999776482582
+          "scale": 0.009999999776482582,
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:classes": [
@@ -125,7 +127,8 @@
         {
           "nodata": 255,
           "data_type": "uint8",
-          "scale": 0.009999999776482582
+          "scale": 0.009999999776482582,
+          "spatial_resolution": 25000.0
         }
       ],
       "roles": [
@@ -137,7 +140,8 @@
       "raster:bands": [
         {
           "nodata": 0,
-          "data_type": "uint8"
+          "data_type": "uint8",
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:bitfields": [
@@ -271,7 +275,8 @@
       "raster:bands": [
         {
           "nodata": 0,
-          "data_type": "uint8"
+          "data_type": "uint8",
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:bitfields": [
@@ -375,7 +380,8 @@
       "raster:bands": [
         {
           "nodata": "nan",
-          "data_type": "float32"
+          "data_type": "float32",
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:classes": [
@@ -409,7 +415,8 @@
       "raster:bands": [
         {
           "nodata": 0,
-          "data_type": "uint8"
+          "data_type": "uint8",
+          "spatial_resolution": 25000.0
         }
       ],
       "classification:classes": [

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0.json
@@ -69,16 +69,6 @@
     }
   ],
   "assets": {
-    "netcdf": {
-      "href": "../../../tests/data-files/external/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223.nc",
-      "type": "application/netcdf",
-      "title": "NOAA Climate Data Record of Sea Surface Temperature - WHOI NetCDF",
-      "description": "SeaFlux Ocean Surface Bundle (OSB) Climate Data Record (CDR) of Sea Surface Temperature",
-      "created": "2021-12-23T18:47:13Z",
-      "roles": [
-        "data"
-      ]
-    },
     "sea_surface_temperature": {
       "href": "./SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0-sea_surface_temperature.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1.json
@@ -69,16 +69,6 @@
     }
   ],
   "assets": {
-    "netcdf": {
-      "href": "../../../tests/data-files/external/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223.nc",
-      "type": "application/netcdf",
-      "title": "NOAA Climate Data Record of Sea Surface Temperature - WHOI NetCDF",
-      "description": "SeaFlux Ocean Surface Bundle (OSB) Climate Data Record (CDR) of Sea Surface Temperature",
-      "created": "2021-12-23T18:47:13Z",
-      "roles": [
-        "data"
-      ]
-    },
     "sea_surface_temperature": {
       "href": "./SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1-sea_surface_temperature.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2.json
@@ -69,16 +69,6 @@
     }
   ],
   "assets": {
-    "netcdf": {
-      "href": "../../../tests/data-files/external/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223.nc",
-      "type": "application/netcdf",
-      "title": "NOAA Climate Data Record of Sea Surface Temperature - WHOI NetCDF",
-      "description": "SeaFlux Ocean Surface Bundle (OSB) Climate Data Record (CDR) of Sea Surface Temperature",
-      "created": "2021-12-23T18:47:13Z",
-      "roles": [
-        "data"
-      ]
-    },
     "sea_surface_temperature": {
       "href": "./SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2-sea_surface_temperature.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3.json
@@ -69,16 +69,6 @@
     }
   ],
   "assets": {
-    "netcdf": {
-      "href": "../../../tests/data-files/external/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223.nc",
-      "type": "application/netcdf",
-      "title": "NOAA Climate Data Record of Sea Surface Temperature - WHOI NetCDF",
-      "description": "SeaFlux Ocean Surface Bundle (OSB) Climate Data Record (CDR) of Sea Surface Temperature",
-      "created": "2021-12-23T18:47:13Z",
-      "roles": [
-        "data"
-      ]
-    },
     "sea_surface_temperature": {
       "href": "./SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3-sea_surface_temperature.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4.json
@@ -69,16 +69,6 @@
     }
   ],
   "assets": {
-    "netcdf": {
-      "href": "../../../tests/data-files/external/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223.nc",
-      "type": "application/netcdf",
-      "title": "NOAA Climate Data Record of Sea Surface Temperature - WHOI NetCDF",
-      "description": "SeaFlux Ocean Surface Bundle (OSB) Climate Data Record (CDR) of Sea Surface Temperature",
-      "created": "2021-12-23T18:47:13Z",
-      "roles": [
-        "data"
-      ]
-    },
     "sea_surface_temperature": {
       "href": "./SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4-sea_surface_temperature.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5.json
@@ -69,16 +69,6 @@
     }
   ],
   "assets": {
-    "netcdf": {
-      "href": "../../../tests/data-files/external/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223.nc",
-      "type": "application/netcdf",
-      "title": "NOAA Climate Data Record of Sea Surface Temperature - WHOI NetCDF",
-      "description": "SeaFlux Ocean Surface Bundle (OSB) Climate Data Record (CDR) of Sea Surface Temperature",
-      "created": "2021-12-23T18:47:13Z",
-      "roles": [
-        "data"
-      ]
-    },
     "sea_surface_temperature": {
       "href": "./SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5-sea_surface_temperature.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6.json
@@ -69,16 +69,6 @@
     }
   ],
   "assets": {
-    "netcdf": {
-      "href": "../../../tests/data-files/external/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223.nc",
-      "type": "application/netcdf",
-      "title": "NOAA Climate Data Record of Sea Surface Temperature - WHOI NetCDF",
-      "description": "SeaFlux Ocean Surface Bundle (OSB) Climate Data Record (CDR) of Sea Surface Temperature",
-      "created": "2021-12-23T18:47:13Z",
-      "roles": [
-        "data"
-      ]
-    },
     "sea_surface_temperature": {
       "href": "./SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6-sea_surface_temperature.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7.json
@@ -69,16 +69,6 @@
     }
   ],
   "assets": {
-    "netcdf": {
-      "href": "../../../tests/data-files/external/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223.nc",
-      "type": "application/netcdf",
-      "title": "NOAA Climate Data Record of Sea Surface Temperature - WHOI NetCDF",
-      "description": "SeaFlux Ocean Surface Bundle (OSB) Climate Data Record (CDR) of Sea Surface Temperature",
-      "created": "2021-12-23T18:47:13Z",
-      "roles": [
-        "data"
-      ]
-    },
     "sea_surface_temperature": {
       "href": "./SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7-sea_surface_temperature.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/collection.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/collection.json
@@ -78,12 +78,6 @@
     "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
-    "netcdf": {
-      "type": "application/netcdf",
-      "roles": [
-        "data"
-      ]
-    },
     "sea_surface_temperature": {
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "raster:bands": [

--- a/scripts/create_examples.py
+++ b/scripts/create_examples.py
@@ -77,7 +77,7 @@ with TemporaryDirectory() as temporary_directory:
 
     print("Creating Sea Surface Temperature - WHOI collection...")
     whoi_sst = whoi_sst_stac.create_collection()
-    whoi_sst_items = whoi_sst_stac.create_items(
+    whoi_sst_items = whoi_sst_stac.create_cog_items(
         str(external_data / "SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223.nc"),
         temporary_directory,
     )

--- a/scripts/create_item_assets.py
+++ b/scripts/create_item_assets.py
@@ -65,5 +65,5 @@ with TemporaryDirectory() as temporary_directory:
 write_item_assets(item, oisst_item_assets_path)
 
 with TemporaryDirectory() as temporary_directory:
-    items = whoi_stac.create_items(str(whoi_data_path), temporary_directory)
+    items = whoi_stac.create_cog_items(str(whoi_data_path), temporary_directory)
 write_item_assets(items[0], whoi_item_assets_path)

--- a/src/stactools/noaa_cdr/sea_ice_concentration/item-assets.json
+++ b/src/stactools/noaa_cdr/sea_ice_concentration/item-assets.json
@@ -11,7 +11,8 @@
       {
         "nodata": 255,
         "data_type": "uint8",
-        "scale": 0.009999999776482582
+        "scale": 0.009999999776482582,
+        "spatial_resolution": 25000.0
       }
     ],
     "classification:classes": [
@@ -46,7 +47,8 @@
       {
         "nodata": 255,
         "data_type": "uint8",
-        "scale": 0.009999999776482582
+        "scale": 0.009999999776482582,
+        "spatial_resolution": 25000.0
       }
     ],
     "classification:classes": [
@@ -81,7 +83,8 @@
       {
         "nodata": 255,
         "data_type": "uint8",
-        "scale": 0.009999999776482582
+        "scale": 0.009999999776482582,
+        "spatial_resolution": 25000.0
       }
     ],
     "roles": [
@@ -93,7 +96,8 @@
     "raster:bands": [
       {
         "nodata": 0,
-        "data_type": "uint8"
+        "data_type": "uint8",
+        "spatial_resolution": 25000.0
       }
     ],
     "classification:bitfields": [
@@ -227,7 +231,8 @@
     "raster:bands": [
       {
         "nodata": 0,
-        "data_type": "uint8"
+        "data_type": "uint8",
+        "spatial_resolution": 25000.0
       }
     ],
     "classification:bitfields": [
@@ -331,7 +336,8 @@
     "raster:bands": [
       {
         "nodata": "nan",
-        "data_type": "float32"
+        "data_type": "float32",
+        "spatial_resolution": 25000.0
       }
     ],
     "classification:classes": [
@@ -365,7 +371,8 @@
     "raster:bands": [
       {
         "nodata": 0,
-        "data_type": "uint8"
+        "data_type": "uint8",
+        "spatial_resolution": 25000.0
       }
     ],
     "classification:classes": [

--- a/src/stactools/noaa_cdr/sea_surface_temperature_whoi/commands.py
+++ b/src/stactools/noaa_cdr/sea_surface_temperature_whoi/commands.py
@@ -17,12 +17,12 @@ def create_command(noaa_cdr: Group) -> Command:
         pass
 
     @sea_surface_temperature_whoi.command(
-        "create-items", short_help="Create a STAC item collection from a NetCDF"
+        "create-cog-items", short_help="Create a STAC item collection from a NetCDF"
     )
     @click.argument("source")
     @click.argument("destination")
-    def create_items(source: str, destination: str) -> None:
-        items = stac.create_items(source, str(Path(destination).parent))
+    def create_cog_items(source: str, destination: str) -> None:
+        items = stac.create_cog_items(source, str(Path(destination).parent))
         for item in items:
             for key, asset in item.assets.items():
                 asset.href = pystac.utils.make_relative_href(asset.href, destination)

--- a/src/stactools/noaa_cdr/sea_surface_temperature_whoi/item-assets.json
+++ b/src/stactools/noaa_cdr/sea_surface_temperature_whoi/item-assets.json
@@ -1,10 +1,4 @@
 {
-  "netcdf": {
-    "type": "application/netcdf",
-    "roles": [
-      "data"
-    ]
-  },
   "sea_surface_temperature": {
     "type": "image/tiff; application=geotiff; profile=cloud-optimized",
     "raster:bands": [

--- a/src/stactools/noaa_cdr/sea_surface_temperature_whoi/stac.py
+++ b/src/stactools/noaa_cdr/sea_surface_temperature_whoi/stac.py
@@ -29,8 +29,9 @@ from .constants import (
 TIME_WINDOW_HALF_WIDTH_IN_MINUTES = int(3 * 60 / 2)
 
 
-def create_items(href: str, directory: str) -> List[Item]:
+def create_cog_items(href: str, directory: str) -> List[Item]:
     base_item = stac.create_item(href)
+    del base_item.assets["netcdf"]
     items = list()
     with fsspec.open(href) as file:
         with xarray.open_dataset(file) as ds:

--- a/tests/ocean_heat_content/test_stac.py
+++ b/tests/ocean_heat_content/test_stac.py
@@ -121,7 +121,8 @@ def test_create_items_one_netcdf_latest_only(tmp_path: Path) -> None:
 def test_cogify(tmp_path: Path, infile: str, num_cogs: int) -> None:
     external_data_path = test_data.get_external_data(infile)
     cogs = cog.cogify(external_data_path, str(tmp_path))
-    assert len(cogs) == num_cogs
+    # Because these netcdfs grow in place, we can never be sure of how many there should be.
+    assert len(cogs) >= num_cogs
     for c in cogs:
         assert Path(c.asset.href).exists()
 

--- a/tests/sea_surface_temperature_whoi/test_commands.py
+++ b/tests/sea_surface_temperature_whoi/test_commands.py
@@ -5,12 +5,12 @@ from pystac import Collection, ItemCollection
 from .. import run_command, test_data
 
 
-def test_create_items(tmp_path: Path) -> None:
+def test_create_cog_items(tmp_path: Path) -> None:
     path = test_data.get_external_data(
         "SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223.nc"
     )
     result = run_command(
-        f"noaa-cdr sea-surface-temperature-whoi create-items {path} {tmp_path}/out.json"
+        f"noaa-cdr sea-surface-temperature-whoi create-cog-items {path} {tmp_path}/out.json"
     )
     assert result.exit_code == 0, result.output
     item_collection = ItemCollection.from_file(str(tmp_path / "out.json"))

--- a/tests/sea_surface_temperature_whoi/test_stac.py
+++ b/tests/sea_surface_temperature_whoi/test_stac.py
@@ -7,20 +7,19 @@ from stactools.noaa_cdr.sea_surface_temperature_whoi import stac
 from .. import test_data
 
 
-def test_create_items(tmp_path: Path) -> None:
+def test_create_cog_items(tmp_path: Path) -> None:
     path = test_data.get_external_data(
         "SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223.nc"
     )
-    items = stac.create_items(path, str(tmp_path))
+    items = stac.create_cog_items(path, str(tmp_path))
     assert len(items) == 8
     for i, item in enumerate(items):
         assert item.id == f"SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-{i}"
         assert item.bbox == [-180, -90, 180, 90]
         assert item.datetime is None
-        assert len(item.assets) == 3
+        assert len(item.assets) == 2
         assert "fill_missing_qc" in item.assets
         assert "sea_surface_temperature" in item.assets
-        assert "netcdf" in item.assets
         item.validate()
 
 


### PR DESCRIPTION
**Description:**
Because those NetCDFs represent a larger time period than the item represents, it doesn't make sense to keep the NetCDFs as assets on the items. The NetCDFs belong on their own items, maybe in their own collection.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Examples have been updated to reflect changes, if applicable
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
