### PR TITLE
Allow skipping of cog creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ number as needed.
 ### Added
 
 - `read_href_modifier` for ocean-heat-content ([#38](https://github.com/stactools-packages/noaa-cdr/pull/38))
+- `cog_hrefs` argument for Ocean Heat Content's cogify, to allow skipping of COG
+  creation ([#39](https://github.com/stactools-packages/noaa-cdr/pull/39))
 
 ### Deprecated
 

--- a/src/stactools/noaa_cdr/ocean_heat_content/cog.py
+++ b/src/stactools/noaa_cdr/ocean_heat_content/cog.py
@@ -19,13 +19,16 @@ from .constants import BASE_TIME
 class Cog:
     """Dataclass to hold the result of a cogification operation."""
 
-    asset: Asset
+    href: str
     profile: BandProfile
     time_resolution: TimeResolution
     start_datetime: datetime.datetime
     end_datetime: datetime.datetime
     datetime: datetime.datetime
     attributes: Dict[Hashable, Any]
+
+    def asset(self) -> Asset:
+        return self.profile.cog_asset(self.href)
 
     def time_interval_as_str(self) -> str:
         """Returns this COG's time interval as a string."""
@@ -52,6 +55,7 @@ def cogify(
     outdir: Optional[str] = None,
     latest_only: bool = False,
     read_href_modifier: Optional[ReadHrefModifier] = None,
+    cog_hrefs: Optional[List[str]] = None,
 ) -> List[Cog]:
     if outdir is None:
         outdir = os.path.dirname(href)
@@ -60,6 +64,10 @@ def cogify(
         maybe_modified_href = read_href_modifier(href)
     else:
         maybe_modified_href = href
+    if cog_hrefs:
+        cog_file_names = dict((os.path.basename(h), h) for h in cog_hrefs)
+    else:
+        cog_file_names = dict()
     with fsspec.open(maybe_modified_href) as file:
         with xarray.open_dataset(file, decode_times=False) as ds:
             time_resolution = TimeResolution.from_value(ds.time_coverage_resolution)
@@ -71,22 +79,25 @@ def cogify(
                 dt = time.add_months_to_datetime(BASE_TIME, month_offset)
                 start_datetime, end_datetime = time_resolution.datetime_bounds(dt)
                 suffix = time_resolution.as_str(dt)
-                path = os.path.join(
-                    outdir,
-                    f"{os.path.splitext(os.path.basename(href))[0]}_{suffix}.tif",
+                file_name = (
+                    f"{os.path.splitext(os.path.basename(href))[0]}_{suffix}.tif"
                 )
                 profile = BandProfile.build(
                     ds, variable, lambda d: d.isel(time=i).squeeze()
                 )
-                values = numpy.flipud(ds[variable].isel(time=i).values.squeeze())
-                asset = cog.write(
-                    values,
-                    path,
-                    profile,
-                )
+                if file_name in cog_file_names:
+                    cog_href = cog_file_names[file_name]
+                else:
+                    cog_href = os.path.join(outdir, file_name)
+                    values = numpy.flipud(ds[variable].isel(time=i).values.squeeze())
+                    cog.write(
+                        values,
+                        cog_href,
+                        profile,
+                    )
                 cogs.append(
                     Cog(
-                        asset=asset,
+                        href=cog_href,
                         profile=profile,
                         time_resolution=time_resolution,
                         datetime=dt,

--- a/src/stactools/noaa_cdr/ocean_heat_content/commands.py
+++ b/src/stactools/noaa_cdr/ocean_heat_content/commands.py
@@ -170,6 +170,6 @@ def create_command(noaa_cdr: Group) -> Command:
         if outdir:
             os.makedirs(str(outdir), exist_ok=True)
         cogs = cog.cogify(infile, None if outdir is None else str(outdir))
-        print(f"Wrote {len(cogs)} COGs to {os.path.dirname(cogs[0].asset.href)}")
+        print(f"Wrote {len(cogs)} COGs to {os.path.dirname(cogs[0].asset().href)}")
 
     return ocean_heat_content

--- a/src/stactools/noaa_cdr/ocean_heat_content/stac.py
+++ b/src/stactools/noaa_cdr/ocean_heat_content/stac.py
@@ -128,6 +128,7 @@ def create_collection(
 def create_items(
     hrefs: List[str],
     directory: str,
+    cog_hrefs: Optional[List[str]] = None,
     latest_only: bool = False,
     read_href_modifier: Optional[ReadHrefModifier] = None,
 ) -> List[Item]:
@@ -144,6 +145,7 @@ def create_items(
         cogs = cog.cogify(
             href,
             directory,
+            cog_hrefs=cog_hrefs,
             latest_only=latest_only,
             read_href_modifier=read_href_modifier,
         )
@@ -175,11 +177,12 @@ def _update_items(items: List[Item], cogs: List[Cog]) -> List[Item]:
         title = c.attributes["title"].split(" : ")[0]
         min_depth = int(c.attributes["geospatial_vertical_min"])
         max_depth = int(c.attributes["geospatial_vertical_max"])
-        c.asset.title = f"{title} : {min_depth}-{max_depth}m {c.time_interval_as_str()}"
-        item.add_asset(c.asset_key(), c.asset)
+        asset = c.asset()
+        asset.title = f"{title} : {min_depth}-{max_depth}m {c.time_interval_as_str()}"
+        item.add_asset(c.asset_key(), asset)
         # The asset has the raster extension, but we need to make sure the item
         # has the schema url.
-        _ = RasterExtension.ext(c.asset, add_if_missing=True)
+        _ = RasterExtension.ext(asset, add_if_missing=True)
         items_as_dict[id] = item
     return list(items_as_dict.values())
 

--- a/src/stactools/noaa_cdr/sea_ice_concentration/cog.py
+++ b/src/stactools/noaa_cdr/sea_ice_concentration/cog.py
@@ -6,13 +6,13 @@ from .. import cog
 from ..profile import BandProfile
 from .constants import SPATIAL_RESOLUTION
 
-KEYS_WITH_CLASSES = [
+VARIABLES_WITH_CLASSES = [
     "cdr_seaice_conc",
     "nsidc_bt_seaice_conc",
     "stdev_of_cdr_seaice_conc",
     "temporal_interpolation_flag",
 ]
-KEYS_WITH_BITFIELDS = ["qa_of_cdr_seaice_conc", "spatial_interpolation_flag"]
+VARIABLES_WITH_BITFIELDS = ["qa_of_cdr_seaice_conc", "spatial_interpolation_flag"]
 
 
 def cogify(href: str, directory: str) -> Dict[str, Asset]:
@@ -20,11 +20,12 @@ def cogify(href: str, directory: str) -> Dict[str, Asset]:
 
 
 class SeaIceConcentrationBandProfile(BandProfile):
-    def update_cog_asset(self, key: str, asset: Asset) -> Asset:
+    def cog_asset(self, href: str) -> Asset:
+        asset = super().cog_asset(href)
         asset.extra_fields["raster:bands"][0]["spatial_resolution"] = SPATIAL_RESOLUTION
-        if key in KEYS_WITH_CLASSES:
+        if self.variable in VARIABLES_WITH_CLASSES:
             asset.extra_fields["classification:classes"] = self.classes()
-        elif key in KEYS_WITH_BITFIELDS:
+        elif self.variable in VARIABLES_WITH_BITFIELDS:
             asset.extra_fields["classification:bitfields"] = self.bitfield()
         return asset
 

--- a/src/stactools/noaa_cdr/sea_surface_temperature_whoi/stac.py
+++ b/src/stactools/noaa_cdr/sea_surface_temperature_whoi/stac.py
@@ -62,8 +62,8 @@ def create_cog_items(href: str, directory: str) -> List[Item]:
                     values = numpy.flipud(ds[variable].isel(time=i).values.squeeze())
                     values = numpy.roll(values, int(profiles[variable].width / 2), 1)
                     path = Path(directory) / f"{item.id}-{variable}.tif"
-                    asset = cog.write(values, str(path), profiles[variable])
-                    item.assets[variable] = asset
+                    cog.write(values, str(path), profiles[variable])
+                    item.assets[variable] = profiles[variable].cog_asset(str(path))
                 items.append(item)
 
     return items


### PR DESCRIPTION
**Related Issue(s):**
- Prompted by https://github.com/stac-utils/stactools/issues/369

**Description:**
Adds a `cog_hrefs` argument to the Ocean Heat Content `create_item` and `cogify` functions. In `cogify`, if a potential new COG's file name matches that of a file name in `cog_hrefs`, skip creating that cog, and instead point that asset's href to the href in `cog_hrefs`. This allows for re-generation of the STAC metadata without re-creating the COGs.

We'll eventually have to do the same for the other CDRs but I wanted to start with this one.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Examples do not change, no update required
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
