### PR TITLE
Support time durations for netcdf items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ number as needed.
 - `cog_hrefs` argument for Ocean Heat Content's cogify, to allow skipping of COG
   creation ([#39](https://github.com/stactools-packages/noaa-cdr/pull/39))
 - `decode_times` argument to `create_item` ([#40](https://github.com/stactools-packages/noaa-cdr/pull/40))
+- Support for `time_coverage_duration` when creating items for NetCDFs ([#41](https://github.com/stactools-packages/noaa-cdr/pull/41))
 
 ### Deprecated
 


### PR DESCRIPTION
**Description:**
To create NetCDF collections, we need to create items for the NetCDFs. The ocean heat content CDR doesn't use have `time_coverage_end` attribute -- rather, it uses `time_coverage_duration`. This adds support for that.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Examples have been updated to reflect changes, if applicable
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
