### PR TITLE
Add time intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- markdownlint-disable MD024 -->
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
@@ -8,6 +10,10 @@ This project attempts to match the major and minor versions of
 number as needed.
 
 ## [Unreleased]
+
+### Added
+
+- Time intervals to NetCDF items and ocean heat content COG items ([#46](https://github.com/stactools-packages/noaa-cdr/pull/46))
 
 ## [0.2.0] - 2023-02-28
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@
   - [raster](https://github.com/stac-extensions/raster)
   - [scientific](https://github.com/stac-extensions/scientific)
   - [classification](https://github.com/stac-extensions/classification)
-- Extra fields: None
+- Extra fields:
+  - `noaa_cdr:interval`: The time resolution (derived from the
+    `time_coverage_resolution` field) of the dataset. Useful for filtering
+    multi-temporal-resolution CDRs, such as ocean heat content.
 - [Browse the example in human-readable form](https://radiantearth.github.io/stac-browser/#/external/raw.githubusercontent.com/stactools-packages/noaa-cdr/main/examples/catalog.json)
 
 ## STAC Examples

--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -35,6 +35,5 @@
       "title": "Sea Ice Concentration CDR"
     }
   ],
-  "stac_extensions": [],
   "title": "Climate Data Records"
 }

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-1972-03-2000m/ocean-heat-content-1972-03-2000m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-1972-03-2000m/ocean-heat-content-1972-03-2000m.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "1972-03-01T00:00:00Z",
     "end_datetime": "1972-03-31T23:59:59Z",
+    "noaa_cdr:interval": "monthly",
     "proj:epsg": 4326,
     "proj:shape": [
       180,
@@ -91,7 +92,7 @@
     90.0
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-ocean-heat-content"

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-1972-03-700m/ocean-heat-content-1972-03-700m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-1972-03-700m/ocean-heat-content-1972-03-700m.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "1972-03-01T00:00:00Z",
     "end_datetime": "1972-03-31T23:59:59Z",
+    "noaa_cdr:interval": "monthly",
     "proj:epsg": 4326,
     "proj:shape": [
       180,
@@ -91,7 +92,7 @@
     90.0
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-ocean-heat-content"

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-100m/ocean-heat-content-2017-2021-100m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-100m/ocean-heat-content-2017-2021-100m.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2017-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
+    "noaa_cdr:interval": "pentadal",
     "proj:epsg": 4326,
     "proj:shape": [
       180,
@@ -105,7 +106,7 @@
     90.0
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-ocean-heat-content"

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-2000m/ocean-heat-content-2017-2021-2000m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-2000m/ocean-heat-content-2017-2021-2000m.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2017-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
+    "noaa_cdr:interval": "pentadal",
     "proj:epsg": 4326,
     "proj:shape": [
       180,
@@ -165,7 +166,7 @@
     90.0
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-ocean-heat-content"

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-700m/ocean-heat-content-2017-2021-700m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2017-2021-700m/ocean-heat-content-2017-2021-700m.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2017-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
+    "noaa_cdr:interval": "pentadal",
     "proj:epsg": 4326,
     "proj:shape": [
       180,
@@ -165,7 +166,7 @@
     90.0
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-ocean-heat-content"

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-100m/ocean-heat-content-2021-100m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-100m/ocean-heat-content-2021-100m.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
+    "noaa_cdr:interval": "yearly",
     "proj:epsg": 4326,
     "proj:shape": [
       180,
@@ -105,7 +106,7 @@
     90.0
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-ocean-heat-content"

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-2000m/ocean-heat-content-2021-2000m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-2000m/ocean-heat-content-2021-2000m.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
+    "noaa_cdr:interval": "yearly",
     "proj:epsg": 4326,
     "proj:shape": [
       180,
@@ -165,7 +166,7 @@
     90.0
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-ocean-heat-content"

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-700m/ocean-heat-content-2021-700m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2021-700m/ocean-heat-content-2021-700m.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
+    "noaa_cdr:interval": "yearly",
     "proj:epsg": 4326,
     "proj:shape": [
       180,
@@ -165,7 +166,7 @@
     90.0
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-ocean-heat-content"

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-100m/ocean-heat-content-2022-Q1-100m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-100m/ocean-heat-content-2022-Q1-100m.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2022-01-01T00:00:00Z",
     "end_datetime": "2022-03-31T23:59:59Z",
+    "noaa_cdr:interval": "seasonal",
     "proj:epsg": 4326,
     "proj:shape": [
       180,
@@ -105,7 +106,7 @@
     90.0
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-ocean-heat-content"

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-2000m/ocean-heat-content-2022-Q1-2000m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-2000m/ocean-heat-content-2022-Q1-2000m.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2022-01-01T00:00:00Z",
     "end_datetime": "2022-03-31T23:59:59Z",
+    "noaa_cdr:interval": "seasonal",
     "proj:epsg": 4326,
     "proj:shape": [
       180,
@@ -165,7 +166,7 @@
     90.0
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-ocean-heat-content"

--- a/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-700m/ocean-heat-content-2022-Q1-700m.json
+++ b/examples/noaa-cdr-ocean-heat-content/ocean-heat-content-2022-Q1-700m/ocean-heat-content-2022-Q1-700m.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2022-01-01T00:00:00Z",
     "end_datetime": "2022-03-31T23:59:59Z",
+    "noaa_cdr:interval": "seasonal",
     "proj:epsg": 4326,
     "proj:shape": [
       180,
@@ -165,7 +166,7 @@
     90.0
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-ocean-heat-content"

--- a/examples/noaa-cdr-sea-ice-concentration/seaice_conc_daily_nh_20211231_f17_v04r00/seaice_conc_daily_nh_20211231_f17_v04r00.json
+++ b/examples/noaa-cdr-sea-ice-concentration/seaice_conc_daily_nh_20211231_f17_v04r00/seaice_conc_daily_nh_20211231_f17_v04r00.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-12-31T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
+    "noaa_cdr:interval": "daily",
     "processing:level": "L3",
     "proj:epsg": null,
     "proj:wkt2": "PROJCRS[\"unknown\",BASEGEOGCRS[\"unknown\",DATUM[\"unknown\",ELLIPSOID[\"unknown\",6378273,298.279411123064,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8901]]],CONVERSION[\"unknown\",METHOD[\"Polar Stereographic (variant B)\",ID[\"EPSG\",9829]],PARAMETER[\"Latitude of standard parallel\",70,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8832]],PARAMETER[\"Longitude of origin\",-45,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8833]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",south,MERIDIAN[90,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]],ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"(N)\",south,MERIDIAN[180,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]],ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
@@ -554,7 +555,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/classification/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-sea-ice-concentration"

--- a/examples/noaa-cdr-sea-surface-temperature-optimum-interpolation/oisst-avhrr-v02r01.20220913/oisst-avhrr-v02r01.20220913.json
+++ b/examples/noaa-cdr-sea-surface-temperature-optimum-interpolation/oisst-avhrr-v02r01.20220913/oisst-avhrr-v02r01.20220913.json
@@ -153,7 +153,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-sea-surface-temperature-optimum-interpolation"
 }

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-0.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-08-31T00:00:00Z",
     "end_datetime": "2021-08-31T03:00:00Z",
+    "noaa_cdr:interval": "three-hourly",
     "processing:level": "L4",
     "proj:epsg": 4326,
     "proj:shape": [
@@ -107,7 +108,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-sea-surface-temperature-whoi"
 }

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-1.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-08-31T03:00:00Z",
     "end_datetime": "2021-08-31T06:00:00Z",
+    "noaa_cdr:interval": "three-hourly",
     "processing:level": "L4",
     "proj:epsg": 4326,
     "proj:shape": [
@@ -107,7 +108,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-sea-surface-temperature-whoi"
 }

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-2.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-08-31T06:00:00Z",
     "end_datetime": "2021-08-31T09:00:00Z",
+    "noaa_cdr:interval": "three-hourly",
     "processing:level": "L4",
     "proj:epsg": 4326,
     "proj:shape": [
@@ -107,7 +108,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-sea-surface-temperature-whoi"
 }

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-3.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-08-31T09:00:00Z",
     "end_datetime": "2021-08-31T12:00:00Z",
+    "noaa_cdr:interval": "three-hourly",
     "processing:level": "L4",
     "proj:epsg": 4326,
     "proj:shape": [
@@ -107,7 +108,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-sea-surface-temperature-whoi"
 }

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-4.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-08-31T12:00:00Z",
     "end_datetime": "2021-08-31T15:00:00Z",
+    "noaa_cdr:interval": "three-hourly",
     "processing:level": "L4",
     "proj:epsg": 4326,
     "proj:shape": [
@@ -107,7 +108,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-sea-surface-temperature-whoi"
 }

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-5.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-08-31T15:00:00Z",
     "end_datetime": "2021-08-31T18:00:00Z",
+    "noaa_cdr:interval": "three-hourly",
     "processing:level": "L4",
     "proj:epsg": 4326,
     "proj:shape": [
@@ -107,7 +108,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-sea-surface-temperature-whoi"
 }

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-6.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-08-31T18:00:00Z",
     "end_datetime": "2021-08-31T21:00:00Z",
+    "noaa_cdr:interval": "three-hourly",
     "processing:level": "L4",
     "proj:epsg": 4326,
     "proj:shape": [
@@ -107,7 +108,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-sea-surface-temperature-whoi"
 }

--- a/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7.json
+++ b/examples/noaa-cdr-sea-surface-temperature-whoi/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7/SEAFLUX-OSB-CDR_V02R00_SST_D20210831_C20211223-7.json
@@ -5,6 +5,7 @@
   "properties": {
     "start_datetime": "2021-08-31T21:00:00Z",
     "end_datetime": "2021-09-01T00:00:00Z",
+    "noaa_cdr:interval": "three-hourly",
     "processing:level": "L4",
     "proj:epsg": 4326,
     "proj:shape": [
@@ -107,7 +108,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "collection": "noaa-cdr-sea-surface-temperature-whoi"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     click-logging >= 1.0.1 
     cftime >= 1.6.2
     h5netcdf >= 1.0.2
+    importlib-resources >= 5.12.0
     numpy >= 1.23.1
     orjson >= 3.8.0
     rasterio >= 1.3.0

--- a/src/stactools/noaa_cdr/constants.py
+++ b/src/stactools/noaa_cdr/constants.py
@@ -7,7 +7,8 @@ GLOBAL_SPATIAL_EXTENT = SpatialExtent(bboxes=GLOBAL_BBOX)
 PROVIDERS = [
     Provider(
         name="National Centers for Environmental Information",
-        description="NCEI is the Nation's leading authority for environmental data, and manage "
+        description="NCEI is the Nation's leading authority for environmental data,"
+        " and manage "
         "one of the largest archives of atmospheric, coastal, geophysical, and "
         "oceanic research in the world. NCEI contributes to the NESDIS mission "
         "by developing new products and services that span the science disciplines "
@@ -31,3 +32,4 @@ CLASSIFICATION_EXTENSION_SCHEMA = (
 )
 NETCDF_ASSET_KEY = "netcdf"
 COMMON_KEYWORDS = ["Global", "Climate", "NOAA"]
+INTERVAL_ATTRIBUTE_NAME = "noaa_cdr:interval"

--- a/src/stactools/noaa_cdr/ocean_heat_content/cog.py
+++ b/src/stactools/noaa_cdr/ocean_heat_content/cog.py
@@ -49,6 +49,10 @@ class Cog:
                 parts.append(part)
         return "_".join(parts)
 
+    def interval(self) -> str:
+        """Returns this cog's interval, e.g. "yearly"."""
+        return self.time_resolution.to_interval()
+
 
 def cogify(
     href: str,

--- a/src/stactools/noaa_cdr/ocean_heat_content/constants.py
+++ b/src/stactools/noaa_cdr/ocean_heat_content/constants.py
@@ -1,7 +1,7 @@
 import datetime
-import importlib.resources
 import json
 
+import importlib_resources
 import pyproj
 from dateutil.tz import tzutc
 from pystac import Extent, Link, MediaType, TemporalExtent
@@ -38,9 +38,9 @@ HOMEPAGE_LINK = Link(
     title="Global Ocean Heat Content CDR",
 )
 ASSET_METADATA = json.loads(
-    importlib.resources.read_text(
-        "stactools.noaa_cdr.ocean_heat_content", "asset-metadata.json"
-    )
+    importlib_resources.files("stactools.noaa_cdr.ocean_heat_content")
+    .joinpath("asset-metadata.json")
+    .read_text()
 )
 DOI = "10.7289/v53f4mvp"
 CITATION = (

--- a/src/stactools/noaa_cdr/ocean_heat_content/stac.py
+++ b/src/stactools/noaa_cdr/ocean_heat_content/stac.py
@@ -14,6 +14,7 @@ from ..constants import (
     DEFAULT_CATALOG_TYPE,
     GLOBAL_BBOX,
     GLOBAL_GEOMETRY,
+    INTERVAL_ATTRIBUTE_NAME,
     LICENSE,
     PROVIDERS,
 )
@@ -172,6 +173,7 @@ def _update_items(items: List[Item], cogs: List[Cog]) -> List[Item]:
                 properties={
                     "start_datetime": pystac.utils.datetime_to_str(c.start_datetime),
                     "end_datetime": pystac.utils.datetime_to_str(c.end_datetime),
+                    INTERVAL_ATTRIBUTE_NAME: c.interval(),
                 },
             )
             projection = ProjectionExtension.ext(item, add_if_missing=True)

--- a/src/stactools/noaa_cdr/sea_ice_concentration/constants.py
+++ b/src/stactools/noaa_cdr/sea_ice_concentration/constants.py
@@ -1,6 +1,6 @@
 import datetime
-import importlib.resources
 
+import importlib_resources
 import orjson
 from dateutil.tz import tzutc
 from pystac import (
@@ -79,9 +79,9 @@ LICENSE_LINK = Link(
 KEYWORDS = COMMON_KEYWORDS + ["Sea ice", "Polar"]
 KEYWORDS.remove("Global")
 ITEM_ASSETS = orjson.loads(
-    importlib.resources.read_text(
-        "stactools.noaa_cdr.sea_ice_concentration", "item-assets.json"
-    )
+    importlib_resources.files("stactools.noaa_cdr.sea_ice_concentration")
+    .joinpath("item-assets.json")
+    .read_text()
 )
 HOMEPAGE_LINK = Link(
     rel="about",

--- a/src/stactools/noaa_cdr/sea_surface_temperature_optimum_interpolation/constants.py
+++ b/src/stactools/noaa_cdr/sea_surface_temperature_optimum_interpolation/constants.py
@@ -1,6 +1,6 @@
 import datetime
-import importlib.resources
 
+import importlib_resources
 import orjson
 from dateutil.tz import tzutc
 from pystac import Extent, Link, MediaType, TemporalExtent
@@ -47,10 +47,11 @@ LICENSE_LINK = Link(
 )
 
 ITEM_ASSETS = orjson.loads(
-    importlib.resources.read_text(
-        "stactools.noaa_cdr.sea_surface_temperature_optimum_interpolation",
-        "item-assets.json",
+    importlib_resources.files(
+        "stactools.noaa_cdr.sea_surface_temperature_optimum_interpolation"
     )
+    .joinpath("item-assets.json")
+    .read_text()
 )
 
 KEYWORDS = COMMON_KEYWORDS + ["Temperature", "Ocean"]

--- a/src/stactools/noaa_cdr/sea_surface_temperature_whoi/constants.py
+++ b/src/stactools/noaa_cdr/sea_surface_temperature_whoi/constants.py
@@ -1,6 +1,6 @@
 import datetime
-import importlib.resources
 
+import importlib_resources
 import orjson
 from dateutil.tz import tzutc
 from pystac import Extent, Link, MediaType, SpatialExtent, TemporalExtent
@@ -46,10 +46,9 @@ LICENSE_LINK = Link(
 KEYWORDS = COMMON_KEYWORDS + ["Ocean", "Temperature"]
 
 ITEM_ASSETS = orjson.loads(
-    importlib.resources.read_text(
-        "stactools.noaa_cdr.sea_surface_temperature_whoi",
-        "item-assets.json",
-    )
+    importlib_resources.files("stactools.noaa_cdr.sea_surface_temperature_whoi")
+    .joinpath("item-assets.json")
+    .read_text()
 )
 HOMEPAGE_LINK = Link(
     rel="about",

--- a/src/stactools/noaa_cdr/time.py
+++ b/src/stactools/noaa_cdr/time.py
@@ -53,6 +53,8 @@ class TimeResolution(str, Enum):
     we only need to handle four cases, this simple structure seemed easier.
     """
 
+    ThreeHourly = "PT3H"
+    Daily = "P1D"
     Monthly = "P01M"
     Seasonal = "P03M"
     Yearly = "P01Y"
@@ -73,9 +75,13 @@ class TimeResolution(str, Enum):
             None,
         )
         if time_resolution is None:
-            raise ValueError(
-                "Encountered unexpected time_coverage_resolution: " f"{value}"
-            )
+            # Sea ice uses P1M for monthly instead of P01M
+            if value == "P1M":
+                return TimeResolution.Monthly
+            else:
+                raise ValueError(
+                    "Encountered unexpected time_coverage_resolution: " f"{value}"
+                )
         else:
             return time_resolution
 
@@ -153,6 +159,31 @@ class TimeResolution(str, Enum):
             return dt.strftime("%Y")
         elif self is TimeResolution.Pentadal:
             return f"{dt.year - 2}-{dt.year + 2}"
+        elif self is TimeResolution.Daily:
+            return dt.strftime(r"%Y-%m-%d")
+        else:
+            raise NotImplementedError
+
+    def to_interval(self) -> str:
+        """Returns this time resolution as a slug-like string.
+
+        Used for the `noaa_cdr:interval` attribute on items.
+
+        Returns:
+            str: This time resolution as a string.
+        """
+        if self is TimeResolution.Monthly:
+            return "monthly"
+        elif self is TimeResolution.Seasonal:
+            return "seasonal"
+        elif self is TimeResolution.Yearly:
+            return "yearly"
+        elif self is TimeResolution.Pentadal:
+            return "pentadal"
+        elif self is TimeResolution.Daily:
+            return "daily"
+        elif self is TimeResolution.ThreeHourly:
+            return "three-hourly"
         else:
             raise NotImplementedError
 

--- a/tests/ocean_heat_content/test_stac.py
+++ b/tests/ocean_heat_content/test_stac.py
@@ -52,6 +52,8 @@ def test_create_items_one_netcdf(tmp_path: Path) -> None:
         )
         assert item.common_metadata.updated is None
 
+        assert item.properties["noaa_cdr:interval"] == "yearly"
+
         proj = ProjectionExtension.ext(item)
         assert proj.epsg == 4326
         assert proj.shape == [180, 360]
@@ -195,15 +197,15 @@ def test_cogify_cog_href(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "infile,year",
+    "infile,year,interval",
     [
-        ("heat_content_anomaly_0-700_yearly.nc", 1955),
-        ("heat_content_anomaly_0-2000_monthly.nc", 2005),
-        ("heat_content_anomaly_0-2000_pentad.nc", 1955),
-        ("heat_content_anomaly_0-2000_seasonal.nc", 2005),
+        ("heat_content_anomaly_0-700_yearly.nc", 1955, "yearly"),
+        ("heat_content_anomaly_0-2000_monthly.nc", 2005, "monthly"),
+        ("heat_content_anomaly_0-2000_pentad.nc", 1955, "pentadal"),
+        ("heat_content_anomaly_0-2000_seasonal.nc", 2005, "seasonal"),
     ],
 )
-def test_create_netcdf_item(infile: str, year: int) -> None:
+def test_create_netcdf_item(infile: str, year: int, interval: str) -> None:
     path = test_data.get_external_data(infile)
     item = stactools.noaa_cdr.stac.create_item(path, decode_times=False)
     assert item.common_metadata.start_datetime == datetime.datetime(
@@ -211,4 +213,5 @@ def test_create_netcdf_item(infile: str, year: int) -> None:
     )
     assert item.common_metadata.end_datetime
     assert item.common_metadata.end_datetime.year != year
+    assert item.properties["noaa_cdr:interval"] == interval
     item.validate()


### PR DESCRIPTION
**Related Issue(s):**
- Closes #45 

**Description:**
This adds time intervals to all NetCDFs that might have them, and to all ocean heat content cogs. It *doesn't*:
- Add intervals to other CDR types (I'll come back and add them later if I think they're appropriate)
- Check to make sure we've captured all necessary `TimeResolution` values (we'll wait for this to error in the test instance and then add back as needed)

Also switches to `importlib_resources` to silence some warnings.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Examples have been updated to reflect changes, if applicable
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
